### PR TITLE
Fix start-claude.sh missing mac compose override on local-mac workspaces

### DIFF
--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -16,12 +16,24 @@ WORKTREE_HELPER="$COMPOSE_DIR/scripts/runtime/worktree-helper.sh"
 MANAGER_PROMPT="$COMPOSE_DIR/scripts/runtime/manager-prompt.txt"
 CONTAINER_PROJECTS="/home/dev/projects"
 
+# Detect workspace type (default to ec2 for backward compatibility)
+WORKSPACE_TYPE="ec2"
+if [[ -f "$COMPOSE_DIR/.env.workspace" ]]; then
+    source "$COMPOSE_DIR/.env.workspace" 2>/dev/null || true
+fi
+
+# Build compose command based on workspace type
+COMPOSE_CMD=(docker compose)
+if [[ "$WORKSPACE_TYPE" == "local-mac" ]]; then
+    COMPOSE_CMD=(docker compose -f docker-compose.yml -f docker-compose.mac.yml)
+fi
+
 # Start container if not running
 if ! docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     echo "Container not running. Starting..."
-    cd "$COMPOSE_DIR" && docker compose up -d
+    cd "$COMPOSE_DIR" && "${COMPOSE_CMD[@]}" up -d
     sleep 2
-    docker compose exec -u root dev bash -c \
+    "${COMPOSE_CMD[@]}" exec -u root dev bash -c \
         "chown -R dev:dev /home/dev/projects" 2>/dev/null || true
 fi
 


### PR DESCRIPTION
## Summary
- Fixes #21
- `start-claude.sh` now detects `WORKSPACE_TYPE` from `.env.workspace` and uses `docker compose -f docker-compose.yml -f docker-compose.mac.yml` on local-mac workspaces
- Defaults to `ec2` (plain `docker compose`) for backward compatibility when `.env.workspace` is missing
- Uses a bash array (`COMPOSE_CMD`) for the compose command, applied to both `up -d` and the `exec` permission fix

## Test plan
- [ ] On a local-mac workspace (with `.env.workspace` containing `WORKSPACE_TYPE=local-mac`), verify `start-claude.sh` starts the container with bridge networking
- [ ] On an EC2 workspace (no `.env.workspace` or `WORKSPACE_TYPE=ec2`), verify the script still uses the default `docker compose up -d`
- [ ] Verify container starts and workspace picker works on both workspace types

🤖 Generated with [Claude Code](https://claude.com/claude-code)