### PR TITLE
Fix bash 3.2 unbound variable on empty arrays in start-claude.sh

### DIFF
--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -34,7 +34,7 @@ discover() {
 
     repos=()
     repo_paths=()
-    for entry in "${entries[@]}"; do
+    for entry in ${entries[@]+"${entries[@]}"}; do
         IFS='|' read -r kind path branch <<< "$entry"
         if [[ "$kind" == "REPO" ]]; then
             repos+=("$path|$branch")


### PR DESCRIPTION
## Summary
- Guards the last remaining unguarded `${entries[@]}` array expansion in `discover()` with the `${arr[@]+"${arr[@]}"}` pattern
- Commit `2b6eaea` fixed `mapfile` (bash 4+) usage and guarded most array expansions, but missed the `for entry in "${entries[@]}"` loop on line 37
- This completes the bash 3.2 compatibility fix for macOS users running the default system bash

Closes #19

## Test plan
- [ ] Run `start-claude.sh` on macOS with `/bin/bash` (bash 3.2) and verify no "unbound variable" errors when `entries` array is empty
- [ ] Run `start-claude.sh` on Linux with bash 5.x to confirm no regressions
- [ ] Verify workspace picker still discovers and lists repos correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)