### PR TITLE
Fix Docker CLI not found on macOS due to App Translocation

### DIFF
--- a/.claude/commands/provision-local.md
+++ b/.claude/commands/provision-local.md
@@ -96,6 +96,15 @@ If Docker is not installed, ask the user:
 
 If installed but not running, tell the user to start Docker Desktop / `colima start`.
 
+Fix App Translocation quarantine (Docker CLI symlinks break when macOS runs Docker from a randomized temp path):
+```bash
+if [[ -d /Applications/Docker.app ]] && xattr -p com.apple.quarantine /Applications/Docker.app 2>/dev/null; then
+    xattr -d com.apple.quarantine /Applications/Docker.app
+    echo "Removed quarantine attribute — quit and reopen Docker Desktop"
+fi
+```
+If the attribute was removed, tell the user to quit and reopen Docker Desktop before continuing.
+
 Verify docker compose works:
 ```bash
 docker compose version

--- a/scripts/deploy/install-mac.sh
+++ b/scripts/deploy/install-mac.sh
@@ -130,6 +130,17 @@ else
     esac
 fi
 
+# Fix App Translocation quarantine (breaks Docker CLI symlinks)
+if [[ -d /Applications/Docker.app ]] && xattr -p com.apple.quarantine /Applications/Docker.app &>/dev/null; then
+    echo "  Removing quarantine attribute from Docker Desktop..."
+    xattr -d com.apple.quarantine /Applications/Docker.app
+    ok "Removed quarantine attribute"
+    echo ""
+    echo "  Docker Desktop was quarantined (App Translocation)."
+    echo "  Please quit and reopen Docker Desktop, then re-run this script."
+    exit 0
+fi
+
 # Ensure docker compose plugin works
 if ! docker compose version &>/dev/null 2>&1; then
     step="docker compose"


### PR DESCRIPTION
## Summary

- Detect and remove the `com.apple.quarantine` extended attribute from `/Applications/Docker.app` in `install-mac.sh` after Docker is installed/detected
- If the attribute was present and removed, prompt the user to quit and reopen Docker Desktop, then re-run the script
- Add the same quarantine fix to the `/provision-local` slash command instructions

Closes #20

## Test plan

- [ ] Install Docker Desktop via direct download (not Homebrew) on macOS
- [ ] Verify `xattr -p com.apple.quarantine /Applications/Docker.app` shows the attribute
- [ ] Run `install-mac.sh` and confirm it detects and removes the quarantine attribute
- [ ] Re-run `install-mac.sh` after reopening Docker Desktop and confirm it proceeds normally
- [ ] Run on a Mac where Docker was installed via Homebrew (no quarantine) and confirm the check is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)