### PR TITLE
Add documentation-fetching MCP servers to workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ WORKDIR /home/dev
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/home/dev/.bun/bin:${PATH}"
 
+# uv — Python package manager, provides uvx for running MCP servers
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
 # Shell aliases
 RUN echo '\n\
 alias cc="claude --dangerously-skip-permissions"\n\

--- a/scripts/deploy/install-mac.sh
+++ b/scripts/deploy/install-mac.sh
@@ -211,7 +211,7 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     chmod +x ~/.claude/statusline-command.sh
     ok "Installed statusline-command.sh"
 
-    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"}}'
+    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"},"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}'
 
     if [[ -f ~/.claude/settings.json ]]; then
         jq --argjson desired "$desired" '$desired * .' \

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -233,7 +233,7 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     ok "Installed statusline-command.sh"
 
     # Build desired user-scope settings
-    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"}}'
+    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"},"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}'
 
     if [[ -f ~/.claude/settings.json ]]; then
         # Merge desired keys into existing settings (existing keys win only if already correct)


### PR DESCRIPTION
## Summary
- Pre-configure **Context7** (`@upstash/context7-mcp`) and **mcp-server-fetch** as user-level MCP servers in `~/.claude/settings.json` during provisioning
- Install **uv** (Python package manager) in the Docker image so `uvx` is available for `mcp-server-fetch`
- Both servers are added to the existing `desired` settings JSON in `install.sh` and `install-mac.sh`, using jq's recursive merge to preserve any existing user MCP server configs

### Why
Many official documentation websites block automated web fetch requests, making it hard for Claude Code to read docs. These two lightweight MCP servers solve this:
- **Context7**: Cloud-indexed library docs (React, Node, AWS, etc.), ~30-50MB RAM, no browser needed
- **mcp-server-fetch**: Pure HTTP fetching with HTML-to-markdown conversion, ~50-80MB RAM, no browser needed

### Files changed
- `Dockerfile` — Install `uv` for `uvx` support
- `scripts/deploy/install.sh` — Add `mcpServers` to desired settings (EC2)
- `scripts/deploy/install-mac.sh` — Add `mcpServers` to desired settings (Mac)

### Design decisions
- MCP config goes in `settings.json` (not baked into Dockerfile) because `~/.claude/` is bind-mounted from the host
- Uses the existing `$desired * .` jq merge pattern — our defaults are added, but existing user customizations win
- Context7 runs via `npx` (already available), fetch runs via `uvx` (newly installed `uv`)

## Test plan
- [ ] Build Docker image locally: `docker compose -f docker-compose.yml -f docker-compose.build.yml build`
- [ ] Verify `uvx` is available inside container: `docker compose exec dev uvx --version`
- [ ] Run `install.sh` on a fresh host and verify `~/.claude/settings.json` contains `mcpServers`
- [ ] Run `install.sh` on a host with existing `settings.json` and verify user configs are preserved
- [ ] Start Claude Code and verify both MCP servers connect successfully

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)