### PR TITLE
Replace hardcoded Ctrl-b with dynamic tmux prefix detection

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -96,7 +96,7 @@ Use this form throughout this command.
      ```
      Then tell the user:
      1. The host user has been renamed from `ubuntu` to `dev`
-     2. They must disconnect (Ctrl-b d, then exit) and reconnect as `dev@`
+     2. They must disconnect (tmux prefix + d, then exit) and reconnect as `dev@`
      3. Update their local SSH config: change `User ubuntu` to `User dev` in `~/.ssh/config`
      4. Update shell aliases if they use `cc`/`ccc`
 

--- a/.claude/commands/workspace.md
+++ b/.claude/commands/workspace.md
@@ -40,4 +40,4 @@ You are helping the user manage git workspaces. This runs on the **host** — `~
 4. After cloning, creating, or deleting a workspace, remind the user:
 
    > Your new repo will appear in the login menu next time you SSH in.
-   > To switch now: press Ctrl-b d to detach, then reconnect via SSH.
+   > To switch now: detach from tmux (prefix + d), then reconnect via SSH.

--- a/scripts/runtime/manager-prompt.txt
+++ b/scripts/runtime/manager-prompt.txt
@@ -8,7 +8,7 @@ You are the Workspace Manager. When the user starts this session, proactively gr
 - **Enable Tailscale** — set up private SSH access via your Tailscale network
 
 ## How to connect to a workspace after changes
-After cloning or creating a worktree, press **Ctrl-b d** to detach from this session, then SSH back in. Your new repo will appear in the login menu — pick it to launch Claude Code inside the container.
+After cloning or creating a worktree, detach from this tmux session (prefix + d), then SSH back in. Your new repo will appear in the login menu — pick it to launch Claude Code inside the container. To find your tmux prefix key, run `tmux show-option -gv prefix`.
 
 Use /workspace to run the workspace manager slash command.
 Use /tailscale to set up Tailscale for private SSH access.

--- a/scripts/runtime/onboarding-prompt.txt
+++ b/scripts/runtime/onboarding-prompt.txt
@@ -70,7 +70,7 @@ After setup is complete, give a brief tour:
 
 **Manage workspaces:** Press [m] at the picker to clone more repos, create worktrees for parallel branches, and more.
 
-**Detach/reattach:** Press Ctrl-b d to detach from a session without stopping it. It keeps running in the background.
+**Detach/reattach:** Press your tmux prefix + d to detach from a session without stopping it. It keeps running in the background. (Run `tmux show-option -gv prefix` to check your prefix key.)
 
 **Mobile tip:** Use a terminal app like Blink (iOS) or Termux (Android). The workspace picker is designed for quick one-key selection."
 
@@ -81,7 +81,7 @@ After the tour, run this command to mark onboarding as done:
 touch ~/.workspace-initialized
 ```
 
-Then say: "Onboarding complete! Press Ctrl-b d to detach, then SSH back in to see the workspace picker with your repos."
+Then say: "Onboarding complete! Detach from tmux (prefix + d) and SSH back in to see the workspace picker with your repos."
 
 ## Important rules
 

--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -18,6 +18,15 @@ CONTAINER_PROJECTS="/home/dev/projects"
 
 COMPOSE_CMD=(sudo --preserve-env=HOME docker compose)
 
+# --- tmux prefix detection ---
+tmux_detach_hint() {
+    local prefix
+    prefix=$(tmux show-option -gv prefix 2>/dev/null || echo "C-b")
+    local pretty
+    pretty=$(echo "$prefix" | sed 's/C-/Ctrl-/')
+    echo "${pretty} d"
+}
+
 # --- Session limit helpers ---
 count_sessions() {
     tmux list-sessions -F '#{session_name}' 2>/dev/null \
@@ -67,7 +76,7 @@ check_session_limit() {
         echo ""
         echo "  Options:"
         echo "    - Re-attach to an existing session (select it from the menu)"
-        echo "    - Exit a running session (Ctrl-b d to detach, then /exit inside it)"
+        echo "    - Exit a running session ($(tmux_detach_hint) to detach, then /exit inside it)"
         echo ""
         return 1
     fi


### PR DESCRIPTION
## Summary
- Removes all hardcoded `Ctrl-b` tmux prefix references across 5 files
- `start-claude.sh`: detects prefix at runtime via `tmux show-option -gv prefix`
- Prompt templates: use generic "prefix + d" phrasing so instructions stay correct regardless of user's tmux config

Fixes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)