### PR TITLE
Create dev user via cloud-init instead of renaming ubuntu

### DIFF
--- a/.claude/commands/provision.md
+++ b/.claude/commands/provision.md
@@ -90,18 +90,43 @@ aws ec2 describe-images --owners 099720109477 --region "$REGION" \
 
 **If using a pre-built AMI**: launch WITHOUT `--user-data`. The AMI has a systemd service that starts the container on boot, and cloud-init injects the SSH key to the `dev` user automatically.
 
-**If using stock Ubuntu**: launch WITH `--user-data` to run install.sh:
+**If using stock Ubuntu**: launch WITH `--user-data` using multipart MIME to create the `dev` user via cloud-config and run install.sh:
 
 ```bash
+USER_DATA=$(cat <<'USERDATA'
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+
+system_info:
+  default_user:
+    name: dev
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    homedir: /home/dev
+
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/bin/bash
+exec > /var/log/install.log 2>&1
+su - dev -c "NON_INTERACTIVE=1 bash -c 'curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scripts/deploy/install.sh | bash'"
+--==BOUNDARY==--
+USERDATA
+)
+
 aws ec2 run-instances \
     --region "$REGION" \
     --image-id "$AMI_ID" \
     --instance-type "$INSTANCE_TYPE" \
     --key-name "$KEY_NAME" \
     --security-group-ids "$SG_ID" \
-    --user-data '#!/bin/bash
-exec > /var/log/install.log 2>&1
-su - ubuntu -c "NON_INTERACTIVE=1 bash -c '\''curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scripts/deploy/install.sh | bash'\''"' \
+    --user-data "$USER_DATA" \
     --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=20,VolumeType=gp3,DeleteOnTermination=true}' \
     --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=claude-dev},{Key=Project,Value=always-on-claude}]' \
     --query 'Instances[0].InstanceId' --output text
@@ -134,7 +159,7 @@ ssh -t -i $KEY dev@$IP "cloud-init status --wait >/dev/null 2>&1"
 
 Verify container is running:
 ```bash
-ssh -i $KEY dev@$IP "sg docker -c 'docker ps --format {{.Names}}' | grep -q claude-dev"
+ssh -i $KEY dev@$IP "docker ps --format {{.Names}} | grep -q claude-dev"
 ```
 
 ---
@@ -142,7 +167,7 @@ ssh -i $KEY dev@$IP "sg docker -c 'docker ps --format {{.Names}}' | grep -q clau
 ## Step 8 — Interactive auth
 
 ```bash
-ssh -t -i $KEY dev@$IP "sg docker -c 'docker cp ~/dev-env/scripts/deploy/setup-auth.sh claude-dev:/tmp/setup-auth.sh && docker exec -it claude-dev bash /tmp/setup-auth.sh'"
+ssh -t -i $KEY dev@$IP "docker cp ~/dev-env/scripts/deploy/setup-auth.sh claude-dev:/tmp/setup-auth.sh && docker exec -it claude-dev bash /tmp/setup-auth.sh"
 ```
 
 Tell the user what to expect before running it (git config, GitHub CLI, Claude login — each requires browser auth).

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -141,23 +141,6 @@ If the self-update script fails, or if the user wants to inspect changes manuall
 
    - **install.sh changed** (other sections): Review what was added. If new system packages or config steps were added, run those specific steps manually. Do NOT re-run the entire install script.
 
-   - **System user rename** (install.sh contains user rename and current user is `ubuntu`): Apply the rename directly:
-
-     ```bash
-     sudo sed -i '/^ubuntu:/ { s/^ubuntu:/dev:/; s|:/home/ubuntu:|:/home/dev:| }' /etc/passwd
-     sudo sed -i 's/^ubuntu:/dev:/' /etc/shadow /etc/group /etc/gshadow /etc/subuid /etc/subgid 2>/dev/null || true
-     sudo mv /home/ubuntu /home/dev 2>/dev/null || true
-     [[ -f /etc/sudoers.d/90-cloud-init-users ]] && sudo sed -i 's/ubuntu/dev/g' /etc/sudoers.d/90-cloud-init-users
-     export USER=dev HOME=/home/dev
-     ```
-
-     Then tell the user:
-
-     1. The host user has been renamed from `ubuntu` to `dev`
-     2. They must disconnect (tmux prefix + d, then exit) and reconnect as `dev@`
-     3. Update their local SSH config: change `User ubuntu` to `User dev` in `~/.ssh/config`
-     4. Update shell aliases if they use `cc`/`ccc`
-
    - **GitHub Actions changed** (`.github/`): No server-side action needed — these run in CI.
 
    - **CLAUDE.md or docs changed**: No action needed.

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -102,11 +102,25 @@ jobs:
 
       - name: Launch build instance
         run: |
+          # Create dev user directly via cloud-init instead of default ubuntu
+          BUILD_USER_DATA=$(cat <<'USERDATA'
+          #cloud-config
+          system_info:
+            default_user:
+              name: dev
+              shell: /bin/bash
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              groups: [sudo]
+              homedir: /home/dev
+          USERDATA
+          )
+
           INSTANCE_ID=$(aws ec2 run-instances \
             --image-id "$BASE_AMI" \
             --instance-type "${{ matrix.instance_type }}" \
             --key-name "$KEY_NAME" \
             --security-group-ids "$SG_ID" \
+            --user-data "$BUILD_USER_DATA" \
             --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=20,VolumeType=gp3,DeleteOnTermination=true}' \
             --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=ami-builder-${{ matrix.arch }}},{Key=Project,Value=${{ env.PROJECT_TAG }}}]" \
             --query 'Instances[0].InstanceId' --output text)
@@ -126,7 +140,7 @@ jobs:
           echo "Waiting for SSH..."
           for i in $(seq 1 30); do
             if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes \
-              -i /tmp/build-key.pem "ubuntu@${PUBLIC_IP}" "echo ok" 2>&1; then
+              -i /tmp/build-key.pem "dev@${PUBLIC_IP}" "echo ok" 2>&1; then
               echo "SSH ready"
               break
             fi
@@ -138,22 +152,20 @@ jobs:
         run: |
           echo "Copying install.sh to build instance..."
           scp -o StrictHostKeyChecking=no -i /tmp/build-key.pem \
-            scripts/deploy/install.sh "ubuntu@${PUBLIC_IP}:/tmp/install.sh"
+            scripts/deploy/install.sh "dev@${PUBLIC_IP}:/tmp/install.sh"
           echo "Running install.sh..."
           ssh -o StrictHostKeyChecking=no -o BatchMode=yes -i /tmp/build-key.pem \
-            "ubuntu@${PUBLIC_IP}" \
+            "dev@${PUBLIC_IP}" \
             "sudo NON_INTERACTIVE=1 bash /tmp/install.sh"
 
       - name: Clean instance for snapshot
         run: |
-          # install.sh renames ubuntu → dev, so use dev@ for post-install commands.
-          # cloud-init clean causes User Data to re-run on boot — install.sh detects
-          # the pre-baked AMI via .provisioned marker and takes a fast path.
+          # cloud-init clean resets state so it re-runs on boot — this is how
+          # the new instance's EC2 SSH key gets injected into the dev user.
           ssh -o StrictHostKeyChecking=no -o BatchMode=yes -i /tmp/build-key.pem \
             "dev@${PUBLIC_IP}" bash <<'EOF'
           sudo rm -f /etc/ssh/ssh_host_*
           sudo cloud-init clean --logs
-          sudo userdel -r ubuntu 2>/dev/null || true
           rm -f ~/.bash_history
           cd ~/dev-env && sudo docker compose stop 2>/dev/null || true
           EOF

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,7 +134,7 @@ curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scrip
 
 ### Phase 1: Automated (no interaction)
 
-1. **System user**: Renames `ubuntu` → `dev` (matches container user UID 1000)
+1. **System user**: Verifies `dev` user exists (created by cloud-init via user-data)
 2. **System packages**: Docker, Docker Compose, tmux, jq, Node.js 22, GitHub CLI, Claude Code
 3. **Swap**: 2GB swapfile, swappiness=10
 4. **earlyoom**: OOM killer — 5% RAM / 10% swap thresholds. Protects SSH/systemd, prefers killing node/claude

--- a/scripts/deploy/build-ami.sh
+++ b/scripts/deploy/build-ami.sh
@@ -124,12 +124,28 @@ fi
 
 info "Launching build instance"
 
+# Create dev user directly via cloud-init instead of the default ubuntu user.
+# This avoids the fragile sed-based rename in install.sh and ensures clean
+# group membership from the start.
+BUILD_USER_DATA=$(cat <<'USERDATA'
+#cloud-config
+system_info:
+  default_user:
+    name: dev
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    homedir: /home/dev
+USERDATA
+)
+
 INSTANCE_ID=$(aws ec2 run-instances \
     --region "$AWS_REGION" \
     --image-id "$BASE_AMI" \
     --instance-type "$INSTANCE_TYPE" \
     --key-name "$KEY_NAME" \
     --security-group-ids "$SG_ID" \
+    --user-data "$BUILD_USER_DATA" \
     --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=$AMI_BUILD_VOLUME_SIZE,VolumeType=gp3,DeleteOnTermination=true}" \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=ami-builder},{Key=Project,Value=$TAG}]" \
     --query 'Instances[0].InstanceId' \
@@ -154,7 +170,7 @@ ok "Running: $PUBLIC_IP"
 echo "  Waiting for SSH..."
 for i in $(seq 1 30); do
     if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes \
-        -i "$KEY_FILE" "ubuntu@${PUBLIC_IP}" "echo ok" &>/dev/null 2>&1; then
+        -i "$KEY_FILE" "dev@${PUBLIC_IP}" "echo ok" &>/dev/null 2>&1; then
         ok "SSH is ready"
         break
     fi
@@ -169,7 +185,7 @@ info "Running install.sh"
 echo "  Installing Docker, Claude Code, pulling image..."
 echo "  This takes 2-3 minutes..."
 
-ssh -o StrictHostKeyChecking=no -o BatchMode=yes -i "$KEY_FILE" "ubuntu@${PUBLIC_IP}" \
+ssh -o StrictHostKeyChecking=no -o BatchMode=yes -i "$KEY_FILE" "dev@${PUBLIC_IP}" \
     "NON_INTERACTIVE=1 bash -c 'curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scripts/deploy/install.sh | bash'" \
     2>&1 | while IFS= read -r line; do echo "  $line"; done
 
@@ -180,9 +196,8 @@ ok "Install complete"
 info "Preparing instance for snapshot"
 
 # Remove host-specific state that shouldn't be baked into the AMI.
-# cloud-init clean causes cloud-init to re-run User Data (install.sh) on boot.
-# install.sh detects the pre-baked AMI via .provisioned marker and takes a fast
-# path: remove stale ubuntu user, re-clone repo if needed, start container.
+# cloud-init clean resets cloud-init state so it re-runs on boot — this is
+# how the new instance's EC2 SSH key gets injected into the dev user.
 ssh -o StrictHostKeyChecking=no -o BatchMode=yes -i "$KEY_FILE" "dev@${PUBLIC_IP}" bash <<'CLEANUP'
 # Remove SSH host keys (regenerated on boot)
 sudo rm -f /etc/ssh/ssh_host_*
@@ -190,15 +205,11 @@ sudo rm -f /etc/ssh/ssh_host_*
 # Clear cloud-init state so it runs fresh on new instances
 sudo cloud-init clean --logs
 
-# Remove cloud-init's ubuntu user if it exists (will be recreated on boot,
-# then removed by install.sh fast path)
-sudo userdel -r ubuntu 2>/dev/null || true
-
 # Remove bash history
 rm -f ~/.bash_history
 history -c
 
-# Stop the container (will be started via User Data on new instances)
+# Stop the container (will be started by systemd on boot)
 cd ~/dev-env && sudo docker compose stop 2>/dev/null || true
 CLEANUP
 

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -83,36 +83,18 @@ fi
 
 ok "Running as $USER ($(if [[ $EUID -eq 0 ]]; then echo "root"; else echo "non-root, using sudo"; fi)) on $(hostname)"
 
-# --- Rename ubuntu user to dev (matches container user) ---------------------
+# --- Verify dev user exists --------------------------------------------------
+# The dev user is created by cloud-init via user-data (cloud-config) before
+# install.sh runs. Both build-ami.sh and provision.sh pass system_info config
+# that creates dev instead of the default ubuntu user.
 
 info "System user"
-step="rename user"
+step="verify dev user"
 
-if id ubuntu &>/dev/null 2>&1 && ! id dev &>/dev/null 2>&1; then
-    # Fix sudoers FIRST — after /etc/passwd rename, sudo won't recognize
-    # the current user as "ubuntu" so it must already reference "dev"
-    if [[ -f /etc/sudoers.d/90-cloud-init-users ]]; then
-        sudo sed -i 's/ubuntu/dev/g' /etc/sudoers.d/90-cloud-init-users
-    fi
-
-    # Direct file edit avoids usermod's "user is currently logged in" check
-    sudo sed -i '/^ubuntu:/ { s/^ubuntu:/dev:/; s|:/home/ubuntu:|:/home/dev:| }' /etc/passwd
-    sudo sed -i 's/^ubuntu:/dev:/' /etc/shadow /etc/group /etc/gshadow /etc/subuid /etc/subgid 2>/dev/null || true
-
-    # Move home dir — cd out first so CWD doesn't block the move
-    cd /
-    sudo mv /home/ubuntu /home/dev
-
-    # Update current session
-    export USER=dev
-    export HOME=/home/dev
-    cd "$HOME"
-
-    ok "Renamed system user ubuntu → dev"
-elif id dev &>/dev/null 2>&1; then
-    skip "User is already dev"
+if id dev &>/dev/null 2>&1; then
+    ok "User dev exists"
 else
-    skip "User is $(id -un) (no rename needed)"
+    die "Expected 'dev' user to exist. Ensure cloud-config user-data creates it before running install.sh."
 fi
 
 # --- System packages --------------------------------------------------------
@@ -153,10 +135,10 @@ else
     skip "Docker Compose plugin"
 fi
 
-# Ensure current user is in docker group (root doesn't need this)
-if [[ $EUID -ne 0 ]] && ! id -nG "$USER" | grep -qw docker; then
-    sudo usermod -aG docker "$USER"
-    ok "Added $USER to docker group (active after re-login)"
+# Ensure dev user is in docker group
+if ! id -nG dev 2>/dev/null | grep -qw docker; then
+    sudo usermod -aG docker dev
+    ok "Added dev to docker group"
 else
     skip "Docker group membership"
 fi
@@ -492,6 +474,13 @@ step="cloud-init config"
 CLOUDINIT_CFG="/etc/cloud/cloud.cfg.d/99-always-on-claude.cfg"
 if [[ ! -f "$CLOUDINIT_CFG" ]]; then
     cat <<'CLOUDINIT' | sudo tee "$CLOUDINIT_CFG" > /dev/null
+# Top-level groups: ensures dev gets added to docker/sudo on pre-baked AMI
+# boots. cloud-init's add_user() skips groups for existing users, but
+# create_group() always runs usermod -a -G for listed members.
+groups:
+  - docker: [dev]
+  - sudo: [dev]
+
 system_info:
   default_user:
     name: dev

--- a/scripts/deploy/provision.sh
+++ b/scripts/deploy/provision.sh
@@ -239,10 +239,30 @@ LAUNCH_ARGS=(
 if [[ "$USE_CUSTOM_AMI" == "0" ]]; then
     # Stock Ubuntu: full install via User Data
     USER_DATA=$(cat <<'USERDATA'
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+
+# Create dev user directly instead of default ubuntu user
+system_info:
+  default_user:
+    name: dev
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    homedir: /home/dev
+
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+
 #!/bin/bash
 exec > /var/log/install.log 2>&1
-su - ubuntu -c "NON_INTERACTIVE=1 bash -c 'curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scripts/deploy/install.sh | bash'"
-# install.sh renames ubuntu → dev; subsequent logins use dev
+su - dev -c "NON_INTERACTIVE=1 bash -c 'curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scripts/deploy/install.sh | bash'"
+--==BOUNDARY==--
 USERDATA
 )
     LAUNCH_ARGS+=(--user-data "$USER_DATA")


### PR DESCRIPTION
## Summary

- **Root cause fix**: The sed-based `ubuntu→dev` rename in `install.sh` had two bugs: group memberships weren't renamed (e.g. `sudo:x:27:ubuntu` kept stale references), and the `dev` user was never added to the docker group in the AMI snapshot — confirmed by launching a test instance and inspecting `/etc/group`
- **Solution**: Pass cloud-config user-data during instance launch (AMI build + provisioning) that creates the `dev` user directly via cloud-init, eliminating the rename entirely
- **Safety net**: Added top-level `groups:` key to cloud-init config for pre-baked AMI boots, using cloud-init's `create_group()` which always runs `usermod -a -G` even for existing groups (unlike `add_user()` which skips everything for existing users)

### Files changed
- `scripts/deploy/install.sh` — Removed 30-line rename block, replaced with dev user verification, fixed `usermod` to always target `dev`
- `scripts/deploy/build-ami.sh` — Added cloud-config user-data, SSH as `dev@`, removed `userdel -r ubuntu`
- `scripts/deploy/provision.sh` — Multipart MIME user-data: cloud-config creates `dev`, then shell runs `install.sh`
- `.claude/commands/provision.md` — Same multipart MIME approach, removed `sg docker` wrappers
- `.github/workflows/build-ami.yml` — Added cloud-config user-data, SSH/SCP as `dev@`, removed `userdel`
- `.claude/commands/update.md` — Removed obsolete rename migration instructions
- `docs/deployment.md` — Updated description

## Test plan

- [ ] Build new AMI with `build-ami.sh` — verify dev user exists with correct groups
- [ ] Provision from stock Ubuntu (no pre-built AMI) — verify multipart MIME user-data works
- [ ] Provision from pre-built AMI — verify cloud-init `groups:` key adds dev to docker/sudo
- [ ] Verify `docker ps` works as dev without `sg docker` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)