### PR TITLE
Fix dev-env path when run as root and mount into container

### DIFF
--- a/.claude/commands/provision.md
+++ b/.claude/commands/provision.md
@@ -167,7 +167,7 @@ ssh -i $KEY dev@$IP "docker ps --format {{.Names}} | grep -q claude-dev"
 ## Step 8 — Interactive auth
 
 ```bash
-ssh -t -i $KEY dev@$IP "docker cp ~/dev-env/scripts/deploy/setup-auth.sh claude-dev:/tmp/setup-auth.sh && docker exec -it claude-dev bash /tmp/setup-auth.sh"
+ssh -t -i $KEY dev@$IP "docker exec -it claude-dev bash /home/dev/dev-env/scripts/deploy/setup-auth.sh"
 ```
 
 Tell the user what to expect before running it (git config, GitHub CLI, Claude login — each requires browser auth).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
       # GitHub CLI config/auth (shared between host and container)
       - ~/.config/gh:/home/dev/.config/gh
 
+      # Dev-env repo (scripts, configs — read-only, managed on host)
+      - ~/dev-env:/home/dev/dev-env:ro
+
       # SSH keys for GitHub (read-only)
       - ~/.ssh:/home/dev/.ssh:ro
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,7 @@ gl  → git log --oneline -20
 | `~/projects` | `/home/dev/projects` | Code repos |
 | `~/.gitconfig.d` | `/home/dev/.gitconfig.d` | Git config |
 | `~/.config/gh` | `/home/dev/.config/gh` | GitHub CLI auth |
+| `~/dev-env` | `/home/dev/dev-env` | Dev-env repo scripts/configs (read-only) |
 | `~/.ssh` | `/home/dev/.ssh` | SSH keys (read-only) |
 | `~/.ssh/known_hosts` | `/home/dev/.ssh/known_hosts` | Writable override for host fingerprints |
 

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -36,8 +36,10 @@ if [[ -f "$_SCRIPT_DIR/load-config.sh" ]]; then
 else
     # Fallback defaults when running via curl pipe before repo exists
     : "${DOCKER_IMAGE:=ghcr.io/verkyyi/always-on-claude:latest}"
-    : "${DEV_ENV:=$HOME/dev-env}"
-    : "${PROJECTS_DIR:=$HOME/projects}"
+    # Use dev user's home, not $HOME (which is /root when run via sudo)
+    _DEV_HOME=$(eval echo "~dev")
+    : "${DEV_ENV:=$_DEV_HOME/dev-env}"
+    : "${PROJECTS_DIR:=$_DEV_HOME/projects}"
     : "${CONTAINER_NAME:=claude-dev}"
     IMAGE="$DOCKER_IMAGE"
 fi
@@ -95,6 +97,14 @@ if id dev &>/dev/null 2>&1; then
     ok "User dev exists"
 else
     die "Expected 'dev' user to exist. Ensure cloud-config user-data creates it before running install.sh."
+fi
+
+# When running as root (e.g. CI's "sudo bash install.sh"), $HOME is /root.
+# Set it to the dev user's home so all ~ expansions and $HOME references
+# throughout this script create files in the right place.
+if [[ $EUID -eq 0 ]]; then
+    export HOME=$(eval echo "~dev")
+    export USER=dev
 fi
 
 # --- System packages --------------------------------------------------------

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -37,9 +37,9 @@ else
     # Fallback defaults when running via curl pipe before repo exists
     : "${DOCKER_IMAGE:=ghcr.io/verkyyi/always-on-claude:latest}"
     # Use dev user's home, not $HOME (which is /root when run via sudo)
-    _DEV_HOME=$(eval echo "~dev")
-    : "${DEV_ENV:=$_DEV_HOME/dev-env}"
-    : "${PROJECTS_DIR:=$_DEV_HOME/projects}"
+    _DEV_HOME=$(getent passwd dev 2>/dev/null | cut -d: -f6 || echo "$HOME")
+    : "${DEV_ENV:=${_DEV_HOME:-$HOME}/dev-env}"
+    : "${PROJECTS_DIR:=${_DEV_HOME:-$HOME}/projects}"
     : "${CONTAINER_NAME:=claude-dev}"
     IMAGE="$DOCKER_IMAGE"
 fi
@@ -103,8 +103,8 @@ fi
 # Set it to the dev user's home so all ~ expansions and $HOME references
 # throughout this script create files in the right place.
 if [[ $EUID -eq 0 ]]; then
-    export HOME=$(eval echo "~dev")
-    export USER=dev
+    HOME=$(getent passwd dev | cut -d: -f6)
+    export HOME USER=dev
 fi
 
 # --- System packages --------------------------------------------------------

--- a/scripts/deploy/load-config.sh
+++ b/scripts/deploy/load-config.sh
@@ -36,9 +36,9 @@ _defaults() {
     : "${CONTAINER_HOSTNAME:=claude-dev}"
 
     # Paths — use dev user's home, not $HOME (which is /root when run as root)
-    _DEV_HOME=$(eval echo "~${SSH_USER}")
-    : "${DEV_ENV:=$_DEV_HOME/dev-env}"
-    : "${PROJECTS_DIR:=$_DEV_HOME/projects}"
+    _DEV_HOME=$(getent passwd "${SSH_USER}" 2>/dev/null | cut -d: -f6 || echo "$HOME")
+    : "${DEV_ENV:=${_DEV_HOME:-$HOME}/dev-env}"
+    : "${PROJECTS_DIR:=${_DEV_HOME:-$HOME}/projects}"
 
     # AMI build
     : "${AMI_BUILD_INSTANCE_TYPE:=t3.medium}"

--- a/scripts/deploy/load-config.sh
+++ b/scripts/deploy/load-config.sh
@@ -35,9 +35,10 @@ _defaults() {
     : "${CONTAINER_NAME:=claude-dev}"
     : "${CONTAINER_HOSTNAME:=claude-dev}"
 
-    # Paths
-    : "${DEV_ENV:=$HOME/dev-env}"
-    : "${PROJECTS_DIR:=$HOME/projects}"
+    # Paths — use dev user's home, not $HOME (which is /root when run as root)
+    _DEV_HOME=$(eval echo "~${SSH_USER}")
+    : "${DEV_ENV:=$_DEV_HOME/dev-env}"
+    : "${PROJECTS_DIR:=$_DEV_HOME/projects}"
 
     # AMI build
     : "${AMI_BUILD_INSTANCE_TYPE:=t3.medium}"


### PR DESCRIPTION
## Summary

- **Issue A**: `install.sh` cloned dev-env to `/root/dev-env` instead of `/home/dev/dev-env` when run via CI's `sudo bash install.sh`, because `$HOME` was `/root`. Fixed by resolving `DEV_ENV`/`PROJECTS_DIR` from `~dev` (the dev user's passwd entry) and setting `HOME=/home/dev` when running as root.
- **Issue B**: `~/dev-env` was not volume-mounted into the container, so `setup-auth.sh` and other scripts were inaccessible. Fixed by adding `~/dev-env:/home/dev/dev-env:ro` to `docker-compose.yml`.
- Provision skill Step 8 simplified: `docker exec` directly instead of `docker cp` workaround.

## Test plan

- [ ] Run `install.sh` as root (`sudo bash install.sh`) — verify dev-env clones to `/home/dev/dev-env`
- [ ] Run `install.sh` as dev user — verify same path
- [ ] Verify container can access `/home/dev/dev-env/` after `docker compose up`
- [ ] Verify `docker exec claude-dev bash /home/dev/dev-env/scripts/deploy/setup-auth.sh` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)