### PR TITLE
Run install.sh as dev user in CI, not root

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -156,7 +156,7 @@ jobs:
           echo "Running install.sh..."
           ssh -o StrictHostKeyChecking=no -o BatchMode=yes -i /tmp/build-key.pem \
             "dev@${PUBLIC_IP}" \
-            "sudo NON_INTERACTIVE=1 bash /tmp/install.sh"
+            "NON_INTERACTIVE=1 bash /tmp/install.sh"
 
       - name: Clean instance for snapshot
         run: |

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -36,10 +36,8 @@ if [[ -f "$_SCRIPT_DIR/load-config.sh" ]]; then
 else
     # Fallback defaults when running via curl pipe before repo exists
     : "${DOCKER_IMAGE:=ghcr.io/verkyyi/always-on-claude:latest}"
-    # Use dev user's home, not $HOME (which is /root when run via sudo)
-    _DEV_HOME=$(getent passwd dev 2>/dev/null | cut -d: -f6 || echo "$HOME")
-    : "${DEV_ENV:=${_DEV_HOME:-$HOME}/dev-env}"
-    : "${PROJECTS_DIR:=${_DEV_HOME:-$HOME}/projects}"
+    : "${DEV_ENV:=$HOME/dev-env}"
+    : "${PROJECTS_DIR:=$HOME/projects}"
     : "${CONTAINER_NAME:=claude-dev}"
     IMAGE="$DOCKER_IMAGE"
 fi
@@ -97,14 +95,6 @@ if id dev &>/dev/null 2>&1; then
     ok "User dev exists"
 else
     die "Expected 'dev' user to exist. Ensure cloud-config user-data creates it before running install.sh."
-fi
-
-# When running as root (e.g. CI's "sudo bash install.sh"), $HOME is /root.
-# Set it to the dev user's home so all ~ expansions and $HOME references
-# throughout this script create files in the right place.
-if [[ $EUID -eq 0 ]]; then
-    HOME=$(getent passwd dev | cut -d: -f6)
-    export HOME USER=dev
 fi
 
 # --- System packages --------------------------------------------------------

--- a/scripts/deploy/load-config.sh
+++ b/scripts/deploy/load-config.sh
@@ -35,10 +35,9 @@ _defaults() {
     : "${CONTAINER_NAME:=claude-dev}"
     : "${CONTAINER_HOSTNAME:=claude-dev}"
 
-    # Paths — use dev user's home, not $HOME (which is /root when run as root)
-    _DEV_HOME=$(getent passwd "${SSH_USER}" 2>/dev/null | cut -d: -f6 || echo "$HOME")
-    : "${DEV_ENV:=${_DEV_HOME:-$HOME}/dev-env}"
-    : "${PROJECTS_DIR:=${_DEV_HOME:-$HOME}/projects}"
+    # Paths
+    : "${DEV_ENV:=$HOME/dev-env}"
+    : "${PROJECTS_DIR:=$HOME/projects}"
 
     # AMI build
     : "${AMI_BUILD_INSTANCE_TYPE:=t3.medium}"


### PR DESCRIPTION
## Summary

- Drop `sudo` from CI's `bash /tmp/install.sh` — the dev user runs it directly, so `$HOME` is `/home/dev` and all files land in the right place naturally
- Revert the `getent`/HOME override workarounds from #88 — no longer needed since install.sh isn't run as root anymore

## Test plan

- [ ] CI build-ami workflow creates AMI with `~/dev-env` at `/home/dev/dev-env` (not `/root/dev-env`)
- [ ] All host directories (`~/.claude`, `~/projects`, etc.) owned by dev user

🤖 Generated with [Claude Code](https://claude.com/claude-code)