### PR TITLE
Add preview and confirmation step to self-update

### DIFF
--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -29,14 +29,21 @@ For most updates, run the self-update script which handles everything automatica
 bash ~/dev-env/scripts/runtime/self-update.sh
 ```
 
-This single command:
+The script follows a **fetch → preview → confirm → apply** flow:
 
-1. Pulls the latest repo changes
-2. Pulls a new Docker image (only if Dockerfile/compose changed or registry has a newer image)
-3. Updates host-side scripts (statusline, tmux config)
-4. Reports what was updated
+1. Fetches latest changes (without applying)
+2. Shows a categorized preview of ALL changes:
+   - **Container changes** (Dockerfile/compose) — will require restart
+   - **Runtime scripts** (start menu, ssh-login, etc.) — take effect immediately on pull
+   - **Slash commands** — take effect immediately on pull
+   - **Host-side configs** (statusline, tmux) — will be copied
+   - **Deploy scripts** — provision-time only, no runtime effect
+   - **Docs/CI** — no runtime effect
+   - **Docker image** — checks registry for newer image
+3. Asks user to confirm before applying anything
+4. Applies: pulls repo, updates image, copies host scripts
 
-If the script completes successfully with no issues, summarize the output for the user and stop here.
+If the script completes successfully, summarize the output for the user and stop here.
 
 ## Detailed path: manual inspection
 
@@ -48,7 +55,7 @@ If the self-update script fails, or if the user wants to inspect changes manuall
    cat ~/.update-pending 2>/dev/null || echo "No pending updates"
    ```
 
-2. If no pending file exists, pull manually and check:
+2. If no pending file exists, fetch and check:
 
    ```bash
    bash ~/dev-env/scripts/runtime/update.sh
@@ -59,7 +66,6 @@ If the self-update script fails, or if the user wants to inspect changes manuall
 
    ```bash
    # The pending file contains before/after commit hashes and rebuild flag
-   # Use them to see exactly what files changed
    cat ~/.update-pending
    ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       # Dev-env repo (scripts, configs — read-only, managed on host)
       - ~/dev-env:/home/dev/dev-env:ro
 
+      # AWS CLI config/credentials (shared between host and container)
+      - ~/.aws:/home/dev/.aws
+
       # SSH keys for GitHub (read-only)
       - ~/.ssh:/home/dev/.ssh:ro
 

--- a/scripts/runtime/self-update.sh
+++ b/scripts/runtime/self-update.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # self-update.sh — Single command to update the entire dev environment.
 #
-# Updates (in order):
-#   1. Dev environment repo (git pull)
-#   2. Docker image (only if Dockerfile/compose changed)
-#   3. Host-side scripts (statusline, tmux config)
-#   4. Reports what was updated
+# Flow: fetch → preview → confirm → apply
+#
+#   1. Fetch latest changes (without applying)
+#   2. Preview all changes grouped by impact
+#   3. Ask user to confirm
+#   4. Apply: pull, update image, copy host scripts
 #
 # Run manually or via the /update slash command.
 # Preserves running tmux sessions — only restarts container when necessary.
@@ -23,6 +24,7 @@ die()   { echo "ERROR: $*" >&2; exit 1; }
 DEV_ENV="${DEV_ENV:-$HOME/dev-env}"
 UPDATED=()
 NEEDS_RESTART=false
+AUTO_YES="${AUTO_YES:-false}"
 
 # Build the correct docker compose command
 docker_compose() {
@@ -47,93 +49,230 @@ if [[ ! -d "$DEV_ENV/.git" ]]; then
     die "$DEV_ENV is not a git repo. Run install.sh first."
 fi
 
-info "Self-update starting"
+info "Checking for updates"
 echo "  Dev env: $DEV_ENV"
 
-# --- Step 1: Pull latest repo changes --------------------------------------
+# --- Step 1: Fetch (don't pull yet) ----------------------------------------
 
-info "Step 1/4: Dev environment repo"
+info "Step 1/4: Fetching latest changes"
 
 before=$(git -C "$DEV_ENV" rev-parse HEAD)
+git -C "$DEV_ENV" fetch --quiet origin 2>&1
 
-if git -C "$DEV_ENV" pull --ff-only 2>&1; then
-    after=$(git -C "$DEV_ENV" rev-parse HEAD)
-    if [[ "$before" != "$after" ]]; then
+# Check if there are changes to apply
+upstream=$(git -C "$DEV_ENV" rev-parse '@{u}' 2>/dev/null || echo "$before")
+
+if [[ "$before" == "$upstream" ]]; then
+    skip "Repo already up to date"
+    CHANGED_FILES=""
+else
+    echo "  ${before:0:7}..${upstream:0:7} ($(git -C "$DEV_ENV" rev-list --count "${before}..${upstream}") commits)"
+    CHANGED_FILES=$(git -C "$DEV_ENV" diff --name-only "${before}..${upstream}")
+fi
+
+# Also check for Docker image updates (regardless of repo changes)
+IMAGE="ghcr.io/verkyyi/always-on-claude:latest"
+local_digest_before=$(docker_cmd inspect --format='{{.Id}}' "$IMAGE" 2>/dev/null || echo "none")
+
+# --- Step 2: Preview all changes -------------------------------------------
+
+info "Step 2/4: Preview"
+
+has_changes=false
+
+# Categorize changed files by impact area
+if [[ -n "$CHANGED_FILES" ]]; then
+    # Container restart required
+    container_changes=$(echo "$CHANGED_FILES" | grep -E '^(Dockerfile|docker-compose\.yml|docker-compose\.build\.yml)$' || true)
+
+    # Runtime scripts (take effect on git pull — bind mounted or run from ~/dev-env)
+    runtime_changes=$(echo "$CHANGED_FILES" | grep -E '^scripts/runtime/' || true)
+
+    # Deploy/install scripts (provision-time only, informational)
+    deploy_changes=$(echo "$CHANGED_FILES" | grep -E '^scripts/deploy/' || true)
+
+    # Slash commands (take effect on git pull — bind mounted)
+    command_changes=$(echo "$CHANGED_FILES" | grep -E '^\.claude/commands/' || true)
+
+    # Docs and config (no runtime impact)
+    doc_changes=$(echo "$CHANGED_FILES" | grep -E '^(docs/|CLAUDE\.md|README\.md|\.github/|\.env\.example|\.gitignore|\.dockerignore|tests/)' || true)
+
+    # Everything else
+    other_changes=$(echo "$CHANGED_FILES" | grep -vE '^(Dockerfile|docker-compose\.yml|docker-compose\.build\.yml|scripts/runtime/|scripts/deploy/|\.claude/commands/|docs/|CLAUDE\.md|README\.md|\.github/|\.env\.example|\.gitignore|\.dockerignore|tests/)' || true)
+
+    # Show commits
+    echo ""
+    echo "  Commits:"
+    git -C "$DEV_ENV" log --oneline "${before}..${upstream}" | sed 's/^/    /'
+
+    # Container restart
+    if [[ -n "$container_changes" ]]; then
+        has_changes=true
         echo ""
-        echo "  Changes pulled (${before:0:7}..${after:0:7}):"
-        git -C "$DEV_ENV" log --oneline "${before}..${after}" | sed 's/^/    /'
-        UPDATED+=("repo: ${before:0:7}..${after:0:7}")
+        echo "  Container (restart required):"
+        echo "$container_changes" | sed 's/^/    /'
+    fi
 
-        # Detect what changed for smart updates
-        CHANGED_FILES=$(git -C "$DEV_ENV" diff --name-only "${before}..${after}")
-    else
-        skip "Already up to date"
-        CHANGED_FILES=""
+    # Runtime scripts
+    if [[ -n "$runtime_changes" ]]; then
+        has_changes=true
+        echo ""
+        echo "  Runtime scripts (take effect immediately after pull):"
+        echo "$runtime_changes" | sed 's/^/    /'
+    fi
+
+    # Slash commands
+    if [[ -n "$command_changes" ]]; then
+        has_changes=true
+        echo ""
+        echo "  Slash commands (take effect immediately after pull):"
+        echo "$command_changes" | sed 's/^/    /'
+    fi
+
+    # Host-side scripts that need copying
+    host_copy_changes=""
+    if [[ -n "$runtime_changes" ]]; then
+        host_copy_changes=$(echo "$runtime_changes" | grep -E '(statusline-command\.sh|tmux\.conf|tmux-status\.sh)$' || true)
+    fi
+    if [[ -n "$host_copy_changes" ]]; then
+        echo ""
+        echo "  Host-side configs (will be copied outside repo):"
+        echo "$host_copy_changes" | sed 's/^/    /'
+    fi
+
+    # Deploy scripts (informational)
+    if [[ -n "$deploy_changes" ]]; then
+        echo ""
+        echo "  Deploy scripts (provision-time only, no runtime effect):"
+        echo "$deploy_changes" | sed 's/^/    /'
+    fi
+
+    # Docs
+    if [[ -n "$doc_changes" ]]; then
+        echo ""
+        echo "  Docs/CI/config (no runtime effect):"
+        echo "$doc_changes" | sed 's/^/    /'
+    fi
+
+    # Other
+    if [[ -n "$other_changes" ]]; then
+        has_changes=true
+        echo ""
+        echo "  Other:"
+        echo "$other_changes" | sed 's/^/    /'
     fi
 else
-    warn "git pull --ff-only failed (divergent history?). Skipping repo update."
-    after="$before"
-    CHANGED_FILES=""
+    echo "  No repo changes."
 fi
 
-# --- Step 2: Docker image (only if Dockerfile/compose changed) --------------
-
-info "Step 2/4: Docker image"
-
-IMAGE_NEEDS_UPDATE=false
-IMAGE="ghcr.io/verkyyi/always-on-claude:latest"
-
-if [[ -n "$CHANGED_FILES" ]]; then
-    if echo "$CHANGED_FILES" | grep -qE '^(Dockerfile|docker-compose\.yml|docker-compose\.build\.yml)$'; then
-        IMAGE_NEEDS_UPDATE=true
-        echo "  Dockerfile or compose config changed — image update needed"
-    fi
-fi
-
-# Always pull the latest image to check for updates
-# Compare image digests before and after pull to detect genuine updates
-local_digest_before=$(docker_cmd inspect --format='{{.Id}}' "$IMAGE" 2>/dev/null || echo "none")
-echo "  Pulling latest image..."
-docker_cmd pull "$IMAGE" 2>&1
-local_digest_after=$(docker_cmd inspect --format='{{.Id}}' "$IMAGE" 2>/dev/null || echo "none")
-
-if [[ "$IMAGE_NEEDS_UPDATE" == "false" ]]; then
-    # No Dockerfile/compose changes — check if the remote image is newer
-    if [[ "$local_digest_before" != "$local_digest_after" ]]; then
-        IMAGE_NEEDS_UPDATE=true
-        echo "  Newer image available from registry"
+# Check Docker image (lightweight — just check remote digest without pulling)
+echo ""
+echo "  Checking Docker image registry..."
+remote_digest=$(docker_cmd manifest inspect "$IMAGE" 2>/dev/null | grep -m1 '"digest"' | cut -d'"' -f4 || echo "unknown")
+if [[ "$local_digest_before" == "none" ]]; then
+    echo "  No local image — will pull"
+    IMAGE_NEEDS_PULL=true
+    has_changes=true
+elif [[ "$remote_digest" == "unknown" ]]; then
+    echo "  Could not check remote digest — will pull to verify"
+    IMAGE_NEEDS_PULL=true
+    has_changes=true
+else
+    # Compare local repo digest with what compose would use
+    local_repo_digest=$(docker_cmd inspect --format='{{index .RepoDigests 0}}' "$IMAGE" 2>/dev/null | cut -d'@' -f2 || echo "none")
+    if [[ "$local_repo_digest" != "$remote_digest" ]]; then
+        echo "  Newer image available in registry"
+        IMAGE_NEEDS_PULL=true
+        has_changes=true
     else
-        skip "Docker image already latest"
+        echo "  Docker image already latest"
+        IMAGE_NEEDS_PULL=false
     fi
 fi
 
-if [[ "$IMAGE_NEEDS_UPDATE" == "true" ]]; then
-    # Check for active Claude sessions before restarting
-    active_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^claude-' || true)
+IMAGE_NEEDS_RESTART=false
+if [[ "${IMAGE_NEEDS_PULL:-false}" == "true" || -n "${container_changes:-}" ]]; then
+    IMAGE_NEEDS_RESTART=true
+fi
 
+# Active sessions warning
+if [[ "$IMAGE_NEEDS_RESTART" == "true" ]]; then
+    active_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(claude-|shell-)' || true)
     if [[ -n "$active_sessions" ]]; then
         echo ""
-        warn "Active Claude sessions detected:"
-        while IFS= read -r session; do echo "    $session"; done <<< "$active_sessions"
-        echo ""
-        echo "  The container needs to restart to apply image updates."
-        echo "  Sessions will be preserved (tmux runs on the host)."
-        echo ""
+        warn "Active sessions (will survive restart — tmux runs on host):"
+        while IFS= read -r session; do echo "      $session"; done <<< "$active_sessions"
+    fi
+fi
 
-        if [[ -t 0 ]]; then
-            read -rp "  Restart container now? [y/N] " confirm
-            if [[ "$confirm" != [yY] ]]; then
-                echo "  Skipping container restart. Run 'self-update.sh' again when ready."
-                NEEDS_RESTART=true
-            fi
-        else
-            # Non-interactive: skip restart, leave a flag
+# Nothing to do?
+if [[ "$has_changes" == "false" && "${IMAGE_NEEDS_PULL:-false}" == "false" ]]; then
+    echo ""
+    echo "  Everything is up to date. Nothing to do."
+    echo ""
+    rm -f "$HOME/.update-pending"
+    exit 0
+fi
+
+# --- Step 3: Confirm -------------------------------------------------------
+
+info "Step 3/4: Confirm"
+
+if [[ "$AUTO_YES" == "true" ]]; then
+    echo "  AUTO_YES=true — proceeding"
+elif [[ -t 0 ]]; then
+    echo ""
+    if [[ "$IMAGE_NEEDS_RESTART" == "true" ]]; then
+        echo "  This update will restart the container."
+    fi
+    read -rp "  Apply updates? [y/N] " confirm
+    if [[ "$confirm" != [yY] ]]; then
+        echo "  Aborted. No changes applied."
+        exit 0
+    fi
+else
+    # Non-interactive (called from Claude): proceed — Claude already showed preview
+    echo "  Non-interactive mode — proceeding"
+fi
+
+# --- Step 4: Apply ---------------------------------------------------------
+
+info "Step 4/4: Applying updates"
+
+# 4a. Pull repo changes
+if [[ "$before" != "$upstream" ]]; then
+    if git -C "$DEV_ENV" pull --ff-only 2>&1; then
+        after=$(git -C "$DEV_ENV" rev-parse HEAD)
+        ok "Repo updated (${before:0:7}..${after:0:7})"
+        UPDATED+=("repo: ${before:0:7}..${after:0:7}")
+    else
+        warn "git pull --ff-only failed (divergent history?). Skipping repo update."
+    fi
+
+    # Make all scripts executable
+    chmod +x "$DEV_ENV"/scripts/deploy/*.sh "$DEV_ENV"/scripts/runtime/*.sh 2>/dev/null || true
+fi
+
+# 4b. Docker image
+if [[ "$IMAGE_NEEDS_RESTART" == "true" ]]; then
+    echo "  Pulling latest image..."
+    docker_cmd pull "$IMAGE" 2>&1
+
+    # Check for active sessions — ask about restart timing
+    active_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '^(claude-|shell-)' || true)
+    do_restart=true
+
+    if [[ -n "$active_sessions" && "$AUTO_YES" != "true" && -t 0 ]]; then
+        echo ""
+        warn "Active sessions detected. Container restart will briefly disconnect docker exec sessions."
+        read -rp "  Restart container now? [y/N] " restart_confirm
+        if [[ "$restart_confirm" != [yY] ]]; then
+            do_restart=false
             NEEDS_RESTART=true
-            warn "Non-interactive mode — skipping restart. Restart manually when ready."
         fi
     fi
 
-    if [[ "$NEEDS_RESTART" == "false" ]]; then
+    if [[ "$do_restart" == "true" ]]; then
         docker_compose up -d 2>&1
         # Fix container permissions after restart
         docker_compose exec -T -u root dev bash -c \
@@ -143,85 +282,71 @@ if [[ "$IMAGE_NEEDS_UPDATE" == "true" ]]; then
         ok "Container restarted with updated image"
         UPDATED+=("docker-image: updated and restarted")
     else
-        UPDATED+=("docker-image: update pulled, restart pending")
+        UPDATED+=("docker-image: pulled, restart pending")
     fi
+elif [[ "${IMAGE_NEEDS_PULL:-false}" == "true" ]]; then
+    echo "  Pulling latest image..."
+    docker_cmd pull "$IMAGE" 2>&1
+    skip "Image pulled but no restart needed"
 fi
 
-# --- Step 3: Host-side scripts ---------------------------------------------
-
-info "Step 3/4: Host-side scripts"
-
+# 4c. Host-side scripts (copied outside the repo)
 host_updated=false
 
-# Statusline script
 if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     if ! cmp -s "$DEV_ENV/scripts/runtime/statusline-command.sh" ~/.claude/statusline-command.sh 2>/dev/null; then
         cp "$DEV_ENV/scripts/runtime/statusline-command.sh" ~/.claude/statusline-command.sh
         chmod +x ~/.claude/statusline-command.sh
         ok "Updated statusline-command.sh"
         host_updated=true
-    else
-        skip "statusline-command.sh unchanged"
     fi
 fi
 
-# tmux config
 if [[ -f "$DEV_ENV/scripts/runtime/tmux.conf" ]]; then
     if ! cmp -s "$DEV_ENV/scripts/runtime/tmux.conf" ~/.tmux.conf 2>/dev/null; then
         cp "$DEV_ENV/scripts/runtime/tmux.conf" ~/.tmux.conf
         ok "Updated ~/.tmux.conf"
         tmux source-file ~/.tmux.conf 2>/dev/null && ok "Reloaded tmux config" || true
         host_updated=true
-    else
-        skip "tmux.conf unchanged"
     fi
 fi
 
-# tmux status script
 if [[ -f "$DEV_ENV/scripts/runtime/tmux-status.sh" ]]; then
     if ! cmp -s "$DEV_ENV/scripts/runtime/tmux-status.sh" ~/.tmux-status.sh 2>/dev/null; then
         cp "$DEV_ENV/scripts/runtime/tmux-status.sh" ~/.tmux-status.sh
         chmod +x ~/.tmux-status.sh
         ok "Updated ~/.tmux-status.sh"
         host_updated=true
-    else
-        skip "tmux-status.sh unchanged"
     fi
 fi
 
-# Make all scripts executable
-chmod +x "$DEV_ENV"/scripts/deploy/*.sh "$DEV_ENV"/scripts/runtime/*.sh 2>/dev/null || true
-
 if [[ "$host_updated" == "true" ]]; then
     UPDATED+=("host-scripts: updated")
-else
-    skip "All host-side scripts unchanged"
 fi
 
-# --- Step 4: Report --------------------------------------------------------
+# --- Summary ----------------------------------------------------------------
 
-info "Step 4/4: Summary"
+echo ""
+echo "=== Summary ==="
 
-# Clean up the pending file if it existed
 rm -f "$HOME/.update-pending"
 
 if [[ ${#UPDATED[@]} -eq 0 ]]; then
     echo ""
     echo "  Everything is up to date. No changes applied."
-    echo ""
 else
     echo ""
     echo "  Updates applied:"
     for item in "${UPDATED[@]}"; do
         echo "    - $item"
     done
-    echo ""
 fi
 
 if [[ "$NEEDS_RESTART" == "true" ]]; then
+    echo ""
     echo "  NOTE: Container restart is pending. Run this script again or restart manually:"
     echo "    cd ~/dev-env && sudo --preserve-env=HOME docker compose up -d"
-    echo ""
 fi
 
+echo ""
 echo "  Done."

--- a/scripts/runtime/self-update.sh
+++ b/scripts/runtime/self-update.sh
@@ -22,6 +22,7 @@ warn()  { echo "  WARN: $*"; }
 die()   { echo "ERROR: $*" >&2; exit 1; }
 
 DEV_ENV="${DEV_ENV:-$HOME/dev-env}"
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
 UPDATED=()
 NEEDS_RESTART=false
 AUTO_YES="${AUTO_YES:-false}"
@@ -56,13 +57,27 @@ echo "  Dev env: $DEV_ENV"
 
 info "Step 1/4: Fetching latest changes"
 
+current_branch=$(git -C "$DEV_ENV" branch --show-current)
 before=$(git -C "$DEV_ENV" rev-parse HEAD)
 git -C "$DEV_ENV" fetch --quiet origin 2>&1
 
-# Check if there are changes to apply
-upstream=$(git -C "$DEV_ENV" rev-parse '@{u}' 2>/dev/null || echo "$before")
+# Always compare against origin/main, not the current branch upstream
+upstream=$(git -C "$DEV_ENV" rev-parse "origin/$TARGET_BRANCH" 2>/dev/null || echo "$before")
 
-if [[ "$before" == "$upstream" ]]; then
+BRANCH_SWITCH=false
+if [[ "$current_branch" != "$TARGET_BRANCH" ]]; then
+    BRANCH_SWITCH=true
+    echo "  Currently on branch '$current_branch' — will switch to '$TARGET_BRANCH'"
+fi
+
+# Check for local uncommitted changes
+local_changes=$(git -C "$DEV_ENV" status --porcelain 2>/dev/null || true)
+if [[ -n "$local_changes" ]]; then
+    echo "  Local changes detected (will stash and restore):"
+    echo "$local_changes" | sed 's/^/    /'
+fi
+
+if [[ "$before" == "$upstream" && "$BRANCH_SWITCH" == "false" ]]; then
     skip "Repo already up to date"
     CHANGED_FILES=""
 else
@@ -79,6 +94,12 @@ local_digest_before=$(docker_cmd inspect --format='{{.Id}}' "$IMAGE" 2>/dev/null
 info "Step 2/4: Preview"
 
 has_changes=false
+
+if [[ "$BRANCH_SWITCH" == "true" ]]; then
+    has_changes=true
+    echo ""
+    echo "  Branch: $current_branch -> $TARGET_BRANCH"
+fi
 
 # Categorize changed files by impact area
 if [[ -n "$CHANGED_FILES" ]]; then
@@ -240,13 +261,38 @@ fi
 info "Step 4/4: Applying updates"
 
 # 4a. Pull repo changes
-if [[ "$before" != "$upstream" ]]; then
+if [[ "$before" != "$upstream" || "$BRANCH_SWITCH" == "true" ]]; then
+    # Stash local changes if any
+    stashed=false
+    if [[ -n "$local_changes" ]]; then
+        git -C "$DEV_ENV" stash push -m "self-update $(date +%Y%m%d-%H%M%S)" 2>&1
+        stashed=true
+        ok "Stashed local changes"
+    fi
+
+    # Switch to target branch if needed
+    if [[ "$BRANCH_SWITCH" == "true" ]]; then
+        git -C "$DEV_ENV" checkout "$TARGET_BRANCH" 2>&1
+        ok "Switched to $TARGET_BRANCH"
+    fi
+
+    # Pull latest
     if git -C "$DEV_ENV" pull --ff-only 2>&1; then
         after=$(git -C "$DEV_ENV" rev-parse HEAD)
         ok "Repo updated (${before:0:7}..${after:0:7})"
         UPDATED+=("repo: ${before:0:7}..${after:0:7}")
     else
         warn "git pull --ff-only failed (divergent history?). Skipping repo update."
+    fi
+
+    # Restore stashed changes
+    if [[ "$stashed" == "true" ]]; then
+        if git -C "$DEV_ENV" stash pop 2>&1; then
+            ok "Restored local changes"
+        else
+            warn "Stash pop had conflicts — local changes saved in git stash"
+            UPDATED+=("warning: stash pop conflicts, run 'git -C ~/dev-env stash pop' manually")
+        fi
     fi
 
     # Make all scripts executable

--- a/scripts/runtime/update.sh
+++ b/scripts/runtime/update.sh
@@ -34,8 +34,9 @@ if ! git -C "$DEV_ENV" fetch --quiet >> "$LOG_FILE" 2>&1; then
     exit 1
 fi
 
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
 local_head=$(git -C "$DEV_ENV" rev-parse HEAD)
-remote_head=$(git -C "$DEV_ENV" rev-parse '@{upstream}' 2>/dev/null || echo "$local_head")
+remote_head=$(git -C "$DEV_ENV" rev-parse "origin/$TARGET_BRANCH" 2>/dev/null || echo "$local_head")
 
 if [[ "$local_head" == "$remote_head" ]]; then
     log "No updates available"


### PR DESCRIPTION
Restructure self-update.sh from "pull then act" to "fetch, preview, confirm, apply". Shows all changes grouped by impact (container restart, runtime scripts, host configs, docs) before applying anything. Supports AUTO_YES=true for non-interactive use.