### PR TITLE
Return to start menu when exiting a session

### DIFF
--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -210,7 +210,7 @@ launch() {
     echo "  -> $selected"
     echo ""
 
-    exec tmux new-session -A -s "$session_name" \
+    tmux new-session -A -s "$session_name" \
         "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'exec claude'"
 }
 
@@ -226,7 +226,7 @@ launch_host() {
     echo "  -> $dir (host)"
     echo ""
 
-    exec tmux new-session -A -s "claude-manager" \
+    tmux new-session -A -s "claude-manager" \
         "bash -lc 'cd \"$dir\" && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
 }
 
@@ -234,14 +234,14 @@ launch_host() {
 launch_shell_host() {
     echo "  -> host shell"
     echo ""
-    exec tmux new-session -A -s "shell-host" "bash -l"
+    tmux new-session -A -s "shell-host" "bash -l"
 }
 
 # --- Launch a container shell in tmux ---
 launch_shell_container() {
     echo "  -> container shell"
     echo ""
-    exec tmux new-session -A -s "shell-container" \
+    tmux new-session -A -s "shell-container" \
         "docker exec -it ${CONTAINER_NAME} bash -l"
 }
 
@@ -254,7 +254,7 @@ reattach_session() {
         local session_name="${session_line%% *}"
         echo "  -> reattach $session_name"
         echo ""
-        exec tmux attach-session -t "$session_name"
+        tmux attach-session -t "$session_name"
     fi
     return 1
 }

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -4,15 +4,14 @@
 UPDATE_SCRIPT="$REPO_ROOT/scripts/runtime/update.sh"
 
 setup() {
-    git init -q --bare "$TEST_DIR/remote.git"
+    git init -q --bare --initial-branch=main "$TEST_DIR/remote.git"
     git clone -q "$TEST_DIR/remote.git" "$HOME/dev-env"
     git -C "$HOME/dev-env" config user.name "Test"
     git -C "$HOME/dev-env" config user.email "test@test.com"
     touch "$HOME/dev-env/README.md"
     git -C "$HOME/dev-env" add .
     git -C "$HOME/dev-env" commit -q -m "Initial commit"
-    git -C "$HOME/dev-env" push -q origin main 2>/dev/null || \
-        git -C "$HOME/dev-env" push -q origin master 2>/dev/null || true
+    git -C "$HOME/dev-env" push -q origin main
 }
 
 _push_upstream_commit() {


### PR DESCRIPTION
## Summary
- Remove `exec` from all tmux launch calls in `start-claude.sh`
- When a Claude session, shell, or manager exits, user returns to the start menu instead of SSH disconnecting
- User can Ctrl+C the menu to actually disconnect

## Test plan
- [ ] Launch a Claude session, exit — verify menu reappears
- [ ] Launch host shell, exit — verify menu reappears
- [ ] Launch container shell, exit — verify menu reappears
- [ ] Reattach to a session, detach — verify menu reappears
- [ ] Ctrl+C at the menu — verify SSH disconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)