### PR TITLE
Add auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,53 @@
+name: Auto Release
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  check-and-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit threshold and tag
+        run: |
+          # Find the most recent tag
+          LAST_TAG=$(git tag --sort=-v:refname | head -1 || echo "")
+          if [[ -z "$LAST_TAG" ]]; then
+            echo "No previous tags found, counting all commits"
+            RANGE="HEAD"
+          else
+            echo "Last tag: $LAST_TAG"
+            RANGE="${LAST_TAG}..HEAD"
+          fi
+
+          # Count non-merge commits since last tag
+          COUNT=$(git rev-list --count --no-merges "$RANGE")
+          echo "Commits since last tag: $COUNT"
+
+          if [[ "$COUNT" -lt 10 ]]; then
+            echo "Below threshold (10), skipping release"
+            exit 0
+          fi
+
+          # Generate calendar-based tag
+          TAG="v$(date -u +%Y.%m.%d)"
+          echo "Proposed tag: $TAG"
+
+          # Skip if tag already exists
+          if git rev-parse "$TAG" &>/dev/null; then
+            echo "Tag $TAG already exists, skipping"
+            exit 0
+          fi
+
+          # Create and push tag
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Created and pushed tag: $TAG"

--- a/docs/superpowers/specs/2026-03-28-auto-release-design.md
+++ b/docs/superpowers/specs/2026-03-28-auto-release-design.md
@@ -1,0 +1,40 @@
+# Auto-Release Workflow Design
+
+## Summary
+
+A scheduled GitHub Actions workflow that automatically creates version tags when enough commits accumulate on `main`, triggering the existing release pipeline.
+
+## Trigger
+
+- **Schedule:** Daily at midnight UTC (`0 0 * * *`)
+- **Manual:** `workflow_dispatch` for on-demand runs
+
+## Logic
+
+1. Find the most recent `v*` tag, or fall back to the initial commit if none exist
+2. Count non-merge commits on `main` since that tag
+3. If count < 10, exit early with a summary log
+4. Generate tag: `vYYYY.MM.DD` (UTC date)
+5. If that tag already exists, skip (no same-day duplicate releases)
+6. Create and push the tag
+7. The existing `release.yml` triggers on the `v*` tag push and handles:
+   - GitHub Release creation with auto-generated changelog
+   - Docker image version tagging on GHCR
+
+## Versioning
+
+- **Format:** Calendar-based, `vYYYY.MM.DD`
+- **Collision handling:** Skip if tag exists for today
+
+## Threshold
+
+- **10 non-merge commits** since last tag
+
+## Permissions
+
+- `contents: write` — required to push tags
+
+## Files
+
+- **New:** `.github/workflows/auto-release.yml`
+- **Unchanged:** `.github/workflows/release.yml`


### PR DESCRIPTION
## Summary
- Adds a daily scheduled workflow that auto-creates `vYYYY.MM.DD` tags when 10+ non-merge commits accumulate on main since the last tag
- Tag push triggers the existing `release.yml` for GitHub Release creation and Docker image tagging
- Also supports manual trigger via `workflow_dispatch`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Manually trigger via Actions UI to confirm it runs and skips (currently < 10 commits with no prior tags)
- [ ] Once threshold is met, confirm tag creation triggers `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)