### PR TITLE
Improve provisioning flow and deduplicate auth setup

### DIFF
--- a/.claude/commands/provision.md
+++ b/.claude/commands/provision.md
@@ -13,7 +13,7 @@ You are orchestrating the provisioning of an always-on Claude Code workspace on 
 
 If the AWS CLI context above shows an error or is not configured, stop and help the user set it up before proceeding. They need `aws configure` with a valid access key, secret, and region.
 
-If an existing instance is found, ask if they want to reuse it (skip to auth) or destroy and recreate.
+If an existing instance is found, ask if they want to reuse it (skip to auth) or destroy and recreate. **Always confirm before terminating** — termination is irreversible and data on the root volume will be lost.
 
 If `$ARGUMENTS` is provided, parse it for preferences (e.g. region, instance type, name). Anything not specified uses defaults.
 

--- a/.claude/commands/provision.md
+++ b/.claude/commands/provision.md
@@ -181,17 +181,7 @@ Expected: `dev` in docker+sudo groups, container `claude-dev` running, dev-env m
 
 ---
 
-## Step 8 — Interactive auth
-
-```bash
-ssh -t -i $KEY dev@$IP "docker exec -it claude-dev bash /home/dev/dev-env/scripts/deploy/setup-auth.sh"
-```
-
-Tell the user what to expect before running it (git config, GitHub CLI, Claude login — each requires browser auth).
-
----
-
-## Step 9 — Save workspace info
+## Step 8 — Save workspace info
 
 Write provisioning details to `.env.workspace.$INSTANCE_NAME` (gitignored via `.env.*` pattern):
 
@@ -210,7 +200,7 @@ EOF
 
 ---
 
-## Step 10 — SSH config
+## Step 9 — SSH config
 
 **Skip if `~/.ssh/config` is not writable** (e.g. provisioning from inside a container). Instead, show the user the SSH command with the full key path.
 
@@ -228,7 +218,7 @@ Host $INSTANCE_NAME
 
 ---
 
-## Step 11 — Shell aliases
+## Step 10 — Shell aliases
 
 **Skip if shell config files are not writable** (e.g. provisioning from inside a container). Instead, include the connect commands in the summary.
 
@@ -247,7 +237,7 @@ Tell the user to run `source ~/.zshrc` (or open a new terminal) to activate.
 
 ---
 
-## Step 12 — Summary
+## Step 11 — Summary
 
 ```
 Provisioning complete!
@@ -262,7 +252,9 @@ Provisioning complete!
     /destroy $INSTANCE_NAME
 ```
 
-If SSH config and aliases were set up (Steps 10-11), also show the short forms (`cc`, `ccc`, `ssh $INSTANCE_NAME`).
+If SSH config and aliases were set up (Steps 9-10), also show the short forms (`cc`, `ccc`, `ssh $INSTANCE_NAME`).
+
+Your first SSH login will trigger guided onboarding (git config, GitHub auth, Claude login) via an interactive Claude session.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,7 +86,7 @@ The override mechanism preserves env vars set before sourcing `.env` — env var
 | Variable | Default | Purpose |
 |---|---|---|
 | `LOCAL_BUILD` | `0` | Build Docker image locally instead of pulling from GHCR |
-| `NON_INTERACTIVE` | `0` | Skip Phase 2 (interactive auth), for User Data scripts |
+| `NON_INTERACTIVE` | `0` | No longer used (kept for backward compatibility with callers) |
 | `AOC_SSH_PASSWORD` | — | Enable password SSH auth and set password |
 | `AOC_HEARTBEAT_URL` | — | Claude Code heartbeat webhook URL (requires TOKEN) |
 | `AOC_HEARTBEAT_TOKEN` | — | Bearer token for heartbeat webhooks (requires URL) |
@@ -128,15 +128,9 @@ curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scrip
 15. **Docker**: Pulls image, starts container, fixes permissions
 16. **Provisioned marker**: Writes `~/dev-env/.provisioned` with timestamp and commit
 
-### Phase 2: Interactive (browser auth)
+### Auth setup (first SSH login)
 
-Runs `setup-auth.sh` inside the container:
-
-1. **Git config**: `user.name` and `user.email`
-2. **GitHub CLI**: `gh auth login` (browser flow)
-3. **Claude Code**: `claude login` (browser flow for subscription auth)
-
-All steps are idempotent — skips what's already configured.
+Auth is handled by the onboarding flow on first SSH login — Claude walks the user through git config, GitHub auth, and Claude verification interactively. See `scripts/runtime/onboarding-prompt.txt`.
 
 ## Auto-updater
 

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -583,54 +583,5 @@ commit=$(git -C "$DEV_ENV" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 EOF
 ok "Wrote provisioned marker"
 
-if [[ "$NON_INTERACTIVE" == "1" ]]; then
-    echo ""
-    echo "  NON_INTERACTIVE mode — skipping auth setup."
-    echo "  Run setup-auth.sh manually after SSHing in."
-    exit 0
-fi
-
-# ============================================================================
-# Phase 2: Interactive (browser auth needed)
-# ============================================================================
-
 echo ""
-echo "Phase 2: Interactive setup (needs browser)"
-echo ""
-
-# --- In-container auth ------------------------------------------------------
-
-info "Container authentication"
-step="container auth"
-
-echo ""
-echo "  Now we'll set up git, GitHub CLI, and Claude Code inside the container."
-echo ""
-read -rp "  Press Enter to continue... "
-
-run_docker docker compose exec -it dev bash /home/dev/dev-env/scripts/deploy/setup-auth.sh </dev/tty
-
-# --- Final verification -----------------------------------------------------
-
-info "Verification"
-step="verification"
-
-echo ""
-
-# Check container
-if run_docker docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
-    ok "Container '$CONTAINER_NAME' is running"
-else
-    echo "  WARN: Container not running"
-fi
-
-echo ""
-echo "============================================"
-echo "  Setup complete!"
-echo "============================================"
-echo ""
-echo "  Next steps:"
-echo "    1. Log out: exit"
-echo "    2. SSH back in: ssh $USER@$(hostname)"
-echo "    3. The workspace picker will appear — select a repo to start"
-echo ""
+echo "  Connect via SSH to complete setup — Claude will guide you through auth."

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -515,7 +515,7 @@ Type=oneshot
 RemainAfterExit=yes
 Environment=HOME=/home/dev
 WorkingDirectory=$DEV_ENV
-ExecStart=/usr/bin/docker compose up -d
+ExecStart=/usr/bin/docker compose up -d --force-recreate
 ExecStop=/usr/bin/docker compose stop
 
 [Install]

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -6,7 +6,7 @@
 #
 # Options (env vars):
 #   LOCAL_BUILD=1      — build Docker image locally instead of pulling from GHCR
-#   NON_INTERACTIVE=1  — skip Phase 2 (interactive auth), for use in user data scripts
+#   NON_INTERACTIVE=1  — (no longer used, kept for backward compatibility with callers)
 #   AOC_SSH_PASSWORD=x  — enable password SSH auth and set password to x
 #   AOC_HEARTBEAT_URL=x — configure Claude Code heartbeat hooks (requires AOC_HEARTBEAT_TOKEN)
 #   AOC_HEARTBEAT_TOKEN=x — bearer token for heartbeat hooks (requires AOC_HEARTBEAT_URL)

--- a/scripts/runtime/onboarding-prompt.txt
+++ b/scripts/runtime/onboarding-prompt.txt
@@ -47,7 +47,20 @@ gh auth login --web --git-protocol https
 
 Wait for it to complete and confirm success.
 
-### Step 4: Clone first repo
+### Step 4: Verify Claude works in container
+
+Check that Claude Code is accessible inside the container:
+```bash
+docker exec claude-dev claude --version
+```
+
+If this works, Claude auth is shared from the host (where you're running now) into the container via bind mounts. Tell the user:
+
+"Claude Code is working inside the container — your auth is shared automatically."
+
+If it fails, help troubleshoot (container not running, bind mount issue).
+
+### Step 5: Clone first repo
 
 Ask: "What repo would you like to work on? Give me a GitHub URL or owner/repo."
 
@@ -58,7 +71,7 @@ git clone https://github.com/OWNER/REPO.git ~/projects/REPO
 
 If they're not sure, suggest they can skip this and clone later from the workspace manager.
 
-### Step 5: Quick tour
+### Step 6: Quick tour
 
 After setup is complete, give a brief tour:
 
@@ -74,7 +87,7 @@ After setup is complete, give a brief tour:
 
 **Mobile tip:** Use a terminal app like Blink (iOS) or Termux (Android). The workspace picker is designed for quick one-key selection."
 
-### Step 6: Mark complete
+### Step 7: Mark complete
 
 After the tour, run this command to mark onboarding as done:
 ```bash


### PR DESCRIPTION
## Summary

- **Deduplicate auth setup**: Remove interactive auth from both `install.sh` (Phase 2) and `/provision` (Step 8) — auth now happens exactly once during first-SSH onboarding via `onboarding.sh`
- **Add Claude container verification**: New onboarding Step 4 verifies Claude Code works inside the container via bind mounts
- **Fix AMI cold starts**: Systemd service now uses `--force-recreate` so containers start cleanly from pre-built AMI snapshots (previously stuck in `Exited (137)`)
- **Add termination guardrail**: Provision skill now explicitly requires confirmation before terminating instances
- **Speed up login menu**: Eliminate slow AWS CLI call (original commit on this branch)

## Test plan
- [x] `test-load-config.sh` — 12/12 pass
- [x] `test-ssh-login.sh` — 7/7 pass
- [x] `test-ssh-login-new.sh` — 1/1 pass
- [x] `bash -n scripts/deploy/install.sh` — syntax OK
- [ ] Deploy to instance and verify onboarding triggers on first SSH
- [ ] Verify container auto-starts on AMI boot with `--force-recreate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)