### PR TITLE
Pull latest scripts on boot before starting container

### DIFF
--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -515,6 +515,7 @@ Type=oneshot
 RemainAfterExit=yes
 Environment=HOME=/home/dev
 WorkingDirectory=$DEV_ENV
+ExecStartPre=/usr/bin/git -C $DEV_ENV pull --ff-only
 ExecStart=/usr/bin/docker compose up -d --force-recreate
 ExecStop=/usr/bin/docker compose stop
 


### PR DESCRIPTION
Adds ExecStartPre git pull to the systemd service so pre-built AMI boots always get the latest runtime scripts without needing an AMI rebuild for every script change.