### PR TITLE
Rediscover repos on each menu iteration

### DIFF
--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -405,10 +405,10 @@ launch_shell_container() {
 
 # --- Main ---
 ensure_container_bg
-discover_entries
 
 while true; do
-    # Refresh session state each iteration (sessions may have changed)
+    # Refresh repos and session state each iteration
+    discover_entries
     get_sessions
     match_sessions
     compute_default


### PR DESCRIPTION
## Summary

- Move `discover_entries` inside the `while true` loop so newly cloned repos appear after exiting a manage session
- Previously repos were discovered once at startup — cloning a repo in the manager didn't show it until next SSH

## Test plan
- [ ] Clone a repo via manage session, exit, verify it appears in the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)