### PR TITLE
Optimize tmux footer: compact, memory usage, no prefix

### DIFF
--- a/scripts/runtime/tmux-status.sh
+++ b/scripts/runtime/tmux-status.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # tmux-status.sh — Right side of the tmux status bar
 #
-# Shows: 2/3 sess
+# Shows: 1/3  62%
 
-BLUE="#[fg=#7aa2f7]"
+DIM="#[fg=#565f89]"
 
+# Session count
 sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -c '^claude-' || echo 0)
 
-# Calculate max sessions (same formula as start-claude.sh)
 if [[ -n "${MAX_SESSIONS:-}" ]]; then
     max=$MAX_SESSIONS
 else
@@ -25,4 +25,13 @@ else
     [[ $max -lt 1 ]] && max=1
 fi
 
-printf " ${BLUE}%s/%s sess " "$sessions" "$max"
+# Memory usage
+if [[ -f /proc/meminfo ]]; then
+    mem_pct=$(awk '/MemTotal/{t=$2} /MemAvailable/{a=$2} END{printf "%.0f", (t-a)/t*100}' /proc/meminfo)
+elif command -v vm_stat &>/dev/null; then
+    mem_pct=$(vm_stat | awk '/Pages active/{a=$3} /Pages wired/{w=$4} /Pages free/{f=$3} /Pages speculative/{s=$3} END{gsub(/\./,"",a); gsub(/\./,"",w); gsub(/\./,"",f); gsub(/\./,"",s); printf "%.0f", (a+w)/(a+w+f+s)*100}')
+else
+    mem_pct="?"
+fi
+
+printf "${DIM}%s/%s  %s%% " "$sessions" "$max" "$mem_pct"

--- a/scripts/runtime/tmux.conf
+++ b/scripts/runtime/tmux.conf
@@ -16,11 +16,11 @@ set -g status-interval 5
 set -g status-position bottom
 set -g status-style "bg=#1a1b26,fg=#a9b1d6"
 
-# Left: session name (encodes workspace identity from start-claude.sh)
+# Left: session name (strip claude- prefix)
 set -g status-left-length 40
-set -g status-left "#[fg=#7aa2f7,bold] #S #[fg=#565f89]│"
+set -g status-left "#[fg=#7aa2f7,bold] #{s/^claude-//:session_name} "
 
-# Right: active session count
+# Right: session count + memory
 set -g status-right-length 20
 set -g status-right "#(bash ~/.tmux-status.sh)"
 

--- a/tests/test-tmux-status.sh
+++ b/tests/test-tmux-status.sh
@@ -9,7 +9,7 @@ test_format_zero_sessions() {
 
     local output
     output=$(MAX_SESSIONS=3 bash "$STATUS_SCRIPT")
-    assert_contains "$output" "0/3 sess"
+    assert_contains "$output" "0/3"
 }
 
 test_format_multiple_sessions() {
@@ -24,12 +24,12 @@ MOCK
 
     local output
     output=$(MAX_SESSIONS=4 bash "$STATUS_SCRIPT")
-    assert_contains "$output" "2/4 sess"
+    assert_contains "$output" "2/4"
 }
 
 test_respects_max_sessions_env() {
     mock_binary tmux ""
     local output
     output=$(MAX_SESSIONS=7 bash "$STATUS_SCRIPT")
-    assert_contains "$output" "0/7 sess"
+    assert_contains "$output" "0/7"
 }


### PR DESCRIPTION
## Summary

- Strip `claude-` prefix from session names (`claude-manager` → `manager`)
- Remove `│` separator and `sess` label
- Add memory usage percentage to right side
- Dim right side stats for less visual noise

**Before:** ` claude-repo │                    1/3 sess `
**After:** ` repo                         1/3  18% `

## Test plan
- [x] Deployed to live instance, verified rendering
- [x] Prefix strip works for claude-* sessions, leaves others unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)