### PR TITLE
Add AWS CLI v2 to host install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,11 @@ ENV PATH="/home/dev/.bun/bin:${PATH}"
 # uv — Python package manager, provides uvx for running MCP servers
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
+# Pre-cache MCP server packages so first Claude Code launch is fast
+# (without this, npx/uvx download on first run, delaying the theme selector)
+RUN npx -y @upstash/context7-mcp --help >/dev/null 2>&1 || true
+RUN /home/dev/.local/bin/uvx mcp-server-fetch --help >/dev/null 2>&1 || true
+
 # Shell aliases
 RUN printf '\nalias cc="claude --dangerously-skip-permissions"\nalias gs="git status"\nalias gl="git log --oneline -20"\n' >> /home/dev/.bashrc
 

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -167,6 +167,19 @@ else
     skip "GitHub CLI (host)"
 fi
 
+# AWS CLI v2 on host (for workspace management scripts, backups, CloudWatch)
+if ! command -v aws &>/dev/null; then
+    step="AWS CLI v2 install (host)"
+    sudo apt-get install -y -qq unzip
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
+    unzip -qo /tmp/awscliv2.zip -d /tmp
+    sudo /tmp/aws/install
+    rm -rf /tmp/aws /tmp/awscliv2.zip
+    ok "AWS CLI v2 installed on host"
+else
+    skip "AWS CLI v2 (host)"
+fi
+
 # Claude Code on host (for orchestrating updates, setup, container management)
 if ! command -v claude &>/dev/null; then
     step="Claude Code install (host)"

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -579,11 +579,12 @@ fi
 run_docker docker compose up -d
 ok "Container running"
 
-# Fix container permissions (volumes mount as root)
-step="fix container permissions"
+# Fix permissions (volumes mount as root, aws cli may create ~/.aws as root)
+step="fix permissions"
 run_docker docker compose exec -T -u root dev bash -c \
     "chown dev:dev /home/dev/projects /home/dev/.claude" 2>/dev/null || true
-ok "Fixed container permissions"
+[[ -d "$HOME/.aws" ]] && sudo chown -R "$(id -u dev):$(id -g dev)" "$HOME/.aws" 2>/dev/null || true
+ok "Fixed permissions"
 
 echo ""
 echo "============================================"


### PR DESCRIPTION
## Summary
- Adds AWS CLI v2 installation to `install.sh` for the host (AMI level)
- Follows existing idempotent pattern — skips if `aws` already present
- Container-level AWS CLI in Dockerfile remains unchanged

## Test plan
- [ ] CI passes (smoke test, security scan, PR validate)
- [ ] AMI build workflow triggers after merge and completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)