### PR TITLE
Fix AMI build disk exhaustion and pre-create ~/.aws

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ PROJECTS_DIR=$HOME/projects
 AMI_BUILD_INSTANCE_TYPE=t3.medium
 
 # Volume size for AMI builds (minimum for OS + Docker image; instances can use larger volumes)
-AMI_BUILD_VOLUME_SIZE=10
+AMI_BUILD_VOLUME_SIZE=20
 
 # --- Sessions -----------------------------------------------------------------
 

--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -121,7 +121,7 @@ jobs:
             --key-name "$KEY_NAME" \
             --security-group-ids "$SG_ID" \
             --user-data "$BUILD_USER_DATA" \
-            --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=10,VolumeType=gp3,DeleteOnTermination=true}' \
+            --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=20,VolumeType=gp3,DeleteOnTermination=true}' \
             --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=ami-builder-${{ matrix.arch }}},{Key=Project,Value=${{ env.PROJECT_TAG }}}]" \
             --query 'Instances[0].InstanceId' --output text)
           echo "INSTANCE_ID=$INSTANCE_ID" >> "$GITHUB_ENV"

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -300,6 +300,7 @@ mkdir -p ~/.claude/debug
 mkdir -p ~/.config/gh
 mkdir -p "$PROJECTS_DIR"
 mkdir -p ~/.gitconfig.d
+mkdir -p ~/.aws
 
 # Critical: must exist as a FILE with valid JSON before compose up
 # (Docker would create it as a directory if missing)

--- a/scripts/deploy/load-config.sh
+++ b/scripts/deploy/load-config.sh
@@ -42,7 +42,7 @@ _defaults() {
 
     # AMI build
     : "${AMI_BUILD_INSTANCE_TYPE:=t3.medium}"
-    : "${AMI_BUILD_VOLUME_SIZE:=10}"
+    : "${AMI_BUILD_VOLUME_SIZE:=20}"
 }
 
 # --- Load .env ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Bump AMI builder volume 10 → 20 GiB (3 places: workflow hardcode, `load-config.sh` default, `.env.example`). Fixes #112 OOM'd the AMI build at the containerd layer-export step for both arm64 and x86_64.
- Pre-create `~/.aws` on the host in `install.sh` (alongside `.claude`, `.ssh`, `.config/gh`) so Docker bind-mounts a dev-owned dir instead of auto-creating it as root. Prevents `aws configure` from failing to save credentials on fresh workspaces.

## Test plan
- [ ] AMI build workflow runs green on both arm64 and x86_64
- [ ] Fresh provision → `aws configure` saves to `~/.aws/credentials` without permission errors
- [ ] `~/.aws` inside container is owned by `dev:dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)