### PR TITLE
Install global CLAUDE.md template on provision

### DIFF
--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -375,9 +375,11 @@ fi
 # Install once if missing; leave user edits alone on re-runs.
 if [[ -f "$DEV_ENV/scripts/runtime/claude-global.md" ]]; then
     if [[ -f ~/.claude/CLAUDE.md ]]; then
+        # shellcheck disable=SC2088
         skip "~/.claude/CLAUDE.md"
     else
         cp "$DEV_ENV/scripts/runtime/claude-global.md" ~/.claude/CLAUDE.md
+        # shellcheck disable=SC2088
         ok "Installed ~/.claude/CLAUDE.md"
     fi
 fi

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -371,6 +371,17 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     fi
 fi
 
+# Global CLAUDE.md — user-scope instructions shared across all projects.
+# Install once if missing; leave user edits alone on re-runs.
+if [[ -f "$DEV_ENV/scripts/runtime/claude-global.md" ]]; then
+    if [[ -f ~/.claude/CLAUDE.md ]]; then
+        skip "~/.claude/CLAUDE.md"
+    else
+        cp "$DEV_ENV/scripts/runtime/claude-global.md" ~/.claude/CLAUDE.md
+        ok "Installed ~/.claude/CLAUDE.md"
+    fi
+fi
+
 # tmux config — host-side status bar with workspace identity, resource usage
 if [[ -f "$DEV_ENV/scripts/runtime/tmux.conf" ]]; then
     cp "$DEV_ENV/scripts/runtime/tmux.conf" ~/.tmux.conf

--- a/scripts/runtime/claude-global.md
+++ b/scripts/runtime/claude-global.md
@@ -1,0 +1,41 @@
+# Global CLAUDE.md
+
+Applies to every project in this workspace. Edit freely — this file is only installed once, then left alone by updates.
+
+## Environment
+
+- **Runtime**: isolated Docker container on AWS EC2, Ubuntu ARM64 (`aarch64`).
+- **Shell**: bash/zsh inside tmux. Detach with tmux prefix + `d`. Reattach via SSH.
+- **Working user**: `dev`. Home: `/home/dev`. Projects live under `~/projects/`.
+- **Workspace manager repo**: `/home/dev/dev-env`.
+- **Claude auth**: user-provided (BYO). Either `ANTHROPIC_API_KEY` env var or `claude login`. Never attempt to log in on the user's behalf.
+- **AWS**: CLI v2 installed. Credentials, if configured, belong to the user. Pass `--region` explicitly — Route 53 domains always use `us-east-1`.
+
+## Permissions
+
+- **Auto-approve is broad** at the user settings level. Safe because the container is sandboxed and disposable — the same settings would be risky on a personal workstation. Don't suggest tightening permissions unless asked.
+- Still confirm before **destructive** or **externally visible** actions: `rm -rf`, force-push, deleting branches/PRs, sending messages, posting to external services, anything that spends money.
+
+## Tools available
+
+- Standard dev tools: `git`, `gh`, `docker`, `node`, `python`, `ripgrep`, `fzf`, `jq`, `aws`.
+- Mobile-friendly slash commands: `/s` (status), `/d` (deploy), `/l` (logs), `/fix`, `/ship`, `/review`.
+- Workspace lifecycle: `/provision`, `/destroy`, `/update`, `/backup`, `/workspace`, `/tailscale`.
+
+## Communication defaults
+
+- Terse. Lead with the answer. Skip recap and filler.
+- Mobile context (`CLAUDE_MOBILE=1` or narrow terminal): extra-short, one line per status item, no wide tables.
+- When showing long output (logs, diffs, file dumps), summarize first and ask before dumping.
+
+## Git
+
+- Commit style: imperative, sentence case, no period (`Add X`, `Fix Y in Z`). Under ~72 chars.
+- Only create commits when asked. Never push without explicit request.
+
+## Gotchas specific to this runtime
+
+- `~/.claude.json` must exist as a **file**, not a directory, before container start.
+- `~/.claude/debug/` and `~/.claude/remote-settings.json` must be pre-created.
+- Container hostname is fixed (`claude-dev`) to keep OAuth state stable.
+- Repo discovery uses `find $HOME -maxdepth 3` — deeper repos won't show in the picker.


### PR DESCRIPTION
## Summary
- Adds `scripts/runtime/claude-global.md` — a default user-scope CLAUDE.md covering runtime, permissions, tooling, communication, git style, and runtime gotchas.
- `install.sh` now copies it to `~/.claude/CLAUDE.md` if missing; preserves user edits on re-run (`/update`, AMI rebuild).

## Test plan
- [ ] Fresh provision: `~/.claude/CLAUDE.md` is created from the template
- [ ] Re-run `install.sh` with existing `~/.claude/CLAUDE.md`: prints `SKIP` and leaves file untouched
- [ ] `bash -n scripts/deploy/install.sh` passes
- [ ] Delete `~/.claude/CLAUDE.md` and re-run install → file is recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)