### PR TITLE
Extend AMI availability wait to 30 minutes

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -187,8 +187,25 @@ jobs:
           echo "AMI_NAME=$AMI_NAME" >> "$GITHUB_ENV"
           echo "AMI: $NEW_AMI (${{ matrix.arch }})"
 
-          echo "Waiting for AMI to be available..."
-          aws ec2 wait image-available --image-ids "$NEW_AMI"
+          echo "Waiting for AMI to be available (up to 30 min)..."
+          # AWS default waiter caps at ~10 min, which is not enough for larger
+          # images. Poll explicitly so we can wait longer and fail fast on
+          # terminal bad states.
+          deadline=$((SECONDS + 1800))
+          while (( SECONDS < deadline )); do
+            state=$(aws ec2 describe-images --image-ids "$NEW_AMI" \
+              --query 'Images[0].State' --output text 2>/dev/null || echo "pending")
+            case "$state" in
+              available) echo "AMI available after ${SECONDS}s"; break ;;
+              failed|error|invalid|deregistered)
+                echo "AMI entered terminal state: $state" >&2; exit 1 ;;
+            esac
+            sleep 15
+          done
+          if [[ "$state" != "available" ]]; then
+            echo "AMI did not become available within 30 min (last state: $state)" >&2
+            exit 1
+          fi
 
       - name: Deregister old AMIs
         run: |


### PR DESCRIPTION
## Summary
- Replaces `aws ec2 wait image-available` (capped at ~10 min) with an explicit poll loop (up to 30 min).
- Fixes spurious AMI build failures observed on commit `fb6211b` where both x86_64 and arm64 AMIs exceeded the waiter deadline but became available shortly after.

## Test plan
- [ ] Re-run `Build and publish AMI` workflow on main after merge
- [ ] Observe healthy x86_64 and arm64 builds (the AMIs themselves build fine — this only extends the wait)
- [ ] Confirm early exit on terminal states (`failed`, `error`, `invalid`, `deregistered`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)