### PR TITLE
Activate GitHub MCP by default in container launches

### DIFF
--- a/docs/superpowers/plans/2026-04-20-github-mcp-default.md
+++ b/docs/superpowers/plans/2026-04-20-github-mcp-default.md
@@ -1,0 +1,507 @@
+# GitHub MCP Default Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activate the already-installed `github` MCP plugin by default in every Claude session launched inside the dev-env container, reusing the user's existing `gh` CLI auth state.
+
+**Architecture:** One new sourceable shell script (`gh-mcp-env.sh`) emits `GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token)` guarded by `gh`-install + `gh auth status` checks. Installed into `~/.claude/` alongside existing per-container config. Three in-container Claude launch paths (workspace and manager in portable mode, workspace in host mode) are updated to source it before `exec claude`. A 3-line nudge goes into the global CLAUDE.md template so future agents prefer MCP tool calls over `gh` shell calls.
+
+**Tech Stack:** Bash, tests use the repo's existing harness (`tests/test-lib.sh` + `tests/run.sh`).
+
+**Spec:** `docs/superpowers/specs/2026-04-20-github-mcp-default-design.md`
+
+---
+
+## File Structure
+
+| File | Role | Status |
+|---|---|---|
+| `scripts/runtime/gh-mcp-env.sh` | Guarded export — single source of truth | **create** |
+| `tests/test-gh-mcp-env.sh` | Three unit tests for the guard behavior matrix | **create** |
+| `scripts/deploy/install.sh` | Copy `gh-mcp-env.sh` into `~/.claude/` during provision | modify |
+| `scripts/portable/start-claude-portable.sh` | Two in-container launches source the env script | modify |
+| `scripts/runtime/start-claude.sh` | One in-container launch (line 372) sources the env script; host-mode manager untouched | modify |
+| `scripts/runtime/claude-global.md` | 3-line nudge: prefer GitHub MCP tools over `gh` shell | modify |
+
+---
+
+## Task 1: Create `gh-mcp-env.sh` with TDD
+
+**Files:**
+- Create: `tests/test-gh-mcp-env.sh`
+- Create: `scripts/runtime/gh-mcp-env.sh`
+
+- [ ] **Step 1.1: Write failing tests**
+
+Create `tests/test-gh-mcp-env.sh`:
+
+```bash
+#!/bin/bash
+# Tests for scripts/runtime/gh-mcp-env.sh
+
+GH_MCP_ENV_SCRIPT="$REPO_ROOT/scripts/runtime/gh-mcp-env.sh"
+
+# Run the script in a subshell that:
+#   - starts from a clean env (no GITHUB_PERSONAL_ACCESS_TOKEN)
+#   - has PATH=$TEST_DIR/bin (no real gh leaks in)
+# Prints: <token-or-UNSET> on stdout, preserves script stderr
+_run_env_script() {
+    (
+        unset GITHUB_PERSONAL_ACCESS_TOKEN
+        export PATH="$TEST_DIR/bin"
+        source "$GH_MCP_ENV_SCRIPT" 2>"$TEST_DIR/stderr"
+        echo "${GITHUB_PERSONAL_ACCESS_TOKEN:-UNSET}"
+    )
+}
+
+_stderr() {
+    cat "$TEST_DIR/stderr" 2>/dev/null || true
+}
+
+test_gh_missing_no_export_with_hint() {
+    # No gh binary on PATH (TEST_DIR/bin is empty)
+    local result
+    result=$(_run_env_script)
+    assert_eq "UNSET" "$result"
+    assert_contains "$(_stderr)" "GitHub MCP inactive"
+    assert_contains "$(_stderr)" "gh auth login"
+}
+
+test_gh_installed_but_unauthed_no_export_with_hint() {
+    # gh exists but `gh auth status` exits non-zero
+    cat > "$TEST_DIR/bin/gh" <<'MOCK'
+#!/bin/bash
+case "$1 $2" in
+    "auth status") echo "not logged in" >&2; exit 1 ;;
+    *) exit 1 ;;
+esac
+MOCK
+    chmod +x "$TEST_DIR/bin/gh"
+
+    local result
+    result=$(_run_env_script)
+    assert_eq "UNSET" "$result"
+    assert_contains "$(_stderr)" "GitHub MCP inactive"
+}
+
+test_gh_authed_exports_token_silently() {
+    # gh is authed and `gh auth token` prints a token
+    cat > "$TEST_DIR/bin/gh" <<'MOCK'
+#!/bin/bash
+case "$1 $2" in
+    "auth status") exit 0 ;;
+    "auth token") echo "gho_testtoken123" ;;
+    *) exit 0 ;;
+esac
+MOCK
+    chmod +x "$TEST_DIR/bin/gh"
+
+    local result
+    result=$(_run_env_script)
+    assert_eq "gho_testtoken123" "$result"
+    # Hint must NOT appear when MCP successfully activates
+    local stderr
+    stderr=$(_stderr)
+    if [[ "$stderr" == *"GitHub MCP inactive"* ]]; then
+        _fail "stderr unexpectedly contained hint: $stderr"
+    fi
+}
+```
+
+- [ ] **Step 1.2: Run the tests to confirm they fail**
+
+Run: `bash tests/run.sh tests/test-gh-mcp-env.sh`
+
+Expected: all 3 tests fail because `scripts/runtime/gh-mcp-env.sh` doesn't exist yet. Failure message will mention the source command failing.
+
+- [ ] **Step 1.3: Implement `gh-mcp-env.sh`**
+
+Create `scripts/runtime/gh-mcp-env.sh`:
+
+```bash
+#!/usr/bin/env bash
+# gh-mcp-env.sh — Exports GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state so
+# the github MCP server (https://api.githubcopilot.com/mcp/) activates for the
+# Claude session. No-op (with a one-line stderr hint) if gh isn't installed or
+# isn't authed.
+#
+# Sourced by start-claude*.sh just before exec'ing claude.
+#
+# Safe to source under `set -e`: the conditional consumes the exit status, so a
+# missing or unauthed gh never aborts the caller.
+
+if command -v gh &>/dev/null && gh auth status &>/dev/null; then
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+else
+    echo "ℹ GitHub MCP inactive — run 'gh auth login' to enable agent GitHub tools" >&2
+fi
+```
+
+Make executable (not strictly required for a sourced script, but matches the repo convention for scripts in `scripts/runtime/`):
+
+```bash
+chmod +x scripts/runtime/gh-mcp-env.sh
+```
+
+- [ ] **Step 1.4: Run the tests to confirm they pass**
+
+Run: `bash tests/run.sh tests/test-gh-mcp-env.sh`
+
+Expected:
+```
+PASS test_gh_authed_exports_token_silently
+PASS test_gh_installed_but_unauthed_no_export_with_hint
+PASS test_gh_missing_no_export_with_hint
+
+All 3 tests passed
+```
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add scripts/runtime/gh-mcp-env.sh tests/test-gh-mcp-env.sh
+git commit -m "Add gh-mcp-env.sh to export GITHUB_PERSONAL_ACCESS_TOKEN from gh auth"
+```
+
+---
+
+## Task 2: Install `gh-mcp-env.sh` into the container at provision time
+
+**Files:**
+- Modify: `scripts/deploy/install.sh:339-343` — add a copy step next to the existing `statusline-command.sh` install block.
+
+- [ ] **Step 2.1: Add the copy step in `install.sh`**
+
+Locate the existing statusline install block at `scripts/deploy/install.sh:339-343`:
+
+```bash
+# Status line script — copy into ~/.claude/ so it's available inside the container
+if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
+    cp "$DEV_ENV/scripts/runtime/statusline-command.sh" ~/.claude/statusline-command.sh
+    chmod +x ~/.claude/statusline-command.sh
+    ok "Installed statusline-command.sh"
+```
+
+Immediately after the `ok "Installed statusline-command.sh"` line (still inside the same `if` block, before `# Build desired user-scope settings`), insert:
+
+```bash
+    # GitHub MCP auth bridge — sourced by start-claude*.sh to export
+    # GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state.
+    if [[ -f "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ]]; then
+        cp "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ~/.claude/gh-mcp-env.sh
+        chmod +x ~/.claude/gh-mcp-env.sh
+        ok "Installed gh-mcp-env.sh"
+    fi
+```
+
+- [ ] **Step 2.2: Smoke-check the edit**
+
+Run (from repo root):
+```bash
+bash -n scripts/deploy/install.sh
+```
+
+Expected: no output (syntax OK).
+
+Then run:
+```bash
+grep -n "gh-mcp-env.sh" scripts/deploy/install.sh
+```
+
+Expected: 3 matches — the comment line, the `cp` line, and the `ok` line.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add scripts/deploy/install.sh
+git commit -m "Install gh-mcp-env.sh into ~/.claude/ during provision"
+```
+
+---
+
+## Task 3: Wire portable-mode launches to source the env script
+
+**Files:**
+- Modify: `scripts/portable/start-claude-portable.sh:158` — workspace session launch
+- Modify: `scripts/portable/start-claude-portable.sh:170` — manager session launch
+
+Both edits insert `source ~/.claude/gh-mcp-env.sh && ` immediately before `exec claude` inside the `bash -lc '...'` command string.
+
+- [ ] **Step 3.1: Read the current launch lines to lock in exact context**
+
+Run:
+```bash
+sed -n '155,175p' scripts/portable/start-claude-portable.sh
+```
+
+Expected output (confirm lines match before editing):
+```
+    session_name="claude-$(basename "$selected" | tr './:' '-')"
+...
+        "bash -lc 'cd \"$selected\" && exec claude'"
+...
+    exec tmux new-session -A -s "claude-manager" \
+        "bash -lc 'cd \"$dir\" && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
+```
+
+- [ ] **Step 3.2: Edit line 158 (workspace session launch)**
+
+Replace:
+```
+        "bash -lc 'cd \"$selected\" && exec claude'"
+```
+
+with:
+```
+        "bash -lc 'cd \"$selected\" && source ~/.claude/gh-mcp-env.sh && exec claude'"
+```
+
+- [ ] **Step 3.3: Edit line 170 (manager session launch)**
+
+Replace:
+```
+        "bash -lc 'cd \"$dir\" && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
+```
+
+with:
+```
+        "bash -lc 'cd \"$dir\" && source ~/.claude/gh-mcp-env.sh && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
+```
+
+- [ ] **Step 3.4: Syntax check**
+
+Run:
+```bash
+bash -n scripts/portable/start-claude-portable.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 3.5: Confirm both source lines landed**
+
+Run:
+```bash
+grep -c "source ~/.claude/gh-mcp-env.sh" scripts/portable/start-claude-portable.sh
+```
+
+Expected: `2`.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add scripts/portable/start-claude-portable.sh
+git commit -m "Source gh-mcp-env.sh before claude in portable-mode launches"
+```
+
+---
+
+## Task 4: Wire host-mode workspace launch to source the env script
+
+**Files:**
+- Modify: `scripts/runtime/start-claude.sh:372` — workspace session only. Host-mode manager at line 388 is intentionally untouched (runs Claude on the host, where `gh` state and `~/.claude/gh-mcp-env.sh` don't exist — see spec section "Launch script integration").
+
+- [ ] **Step 4.1: Read the current workspace launch line for exact context**
+
+Run:
+```bash
+sed -n '370,374p' scripts/runtime/start-claude.sh
+```
+
+Expected output (confirm the docker exec line matches before editing):
+```
+    tmux new-session -A -s "$session_name" \
+        "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'exec claude'"
+}
+```
+
+- [ ] **Step 4.2: Edit line 372 (workspace session docker exec)**
+
+Replace:
+```
+        "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'exec claude'"
+```
+
+with:
+```
+        "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'source ~/.claude/gh-mcp-env.sh && exec claude'"
+```
+
+- [ ] **Step 4.3: Syntax check**
+
+Run:
+```bash
+bash -n scripts/runtime/start-claude.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 4.4: Confirm source line landed once (host manager at 388 should NOT have it)**
+
+Run:
+```bash
+grep -c "source ~/.claude/gh-mcp-env.sh" scripts/runtime/start-claude.sh
+```
+
+Expected: `1`.
+
+Also confirm the manager launch was NOT touched:
+```bash
+grep -n "Greet me and show" scripts/runtime/start-claude.sh
+```
+
+Expected: one match; the line should still read `"bash -lc 'cd \"$dir\" && exec claude --append-system-prompt-file ...` (no `source` in it).
+
+- [ ] **Step 4.5: Run the existing start-claude test suite to confirm no regression**
+
+Run:
+```bash
+bash tests/run.sh tests/test-start-claude.sh
+```
+
+Expected: all tests pass (these test helper functions, which are unaffected by the launch-line edit).
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add scripts/runtime/start-claude.sh
+git commit -m "Source gh-mcp-env.sh in host-mode workspace launch"
+```
+
+---
+
+## Task 5: Add the "prefer GitHub MCP" nudge to the global CLAUDE.md template
+
+**Files:**
+- Modify: `scripts/runtime/claude-global.md` — add a short rule under the existing `## Tools available` section.
+
+- [ ] **Step 5.1: Read the current `## Tools available` section**
+
+Run:
+```bash
+sed -n '19,24p' scripts/runtime/claude-global.md
+```
+
+Expected:
+```
+## Tools available
+
+- Standard dev tools: `git`, `gh`, `docker`, `node`, `python`, `ripgrep`, `fzf`, `jq`, `aws`.
+- Mobile-friendly slash commands: `/s` (status), `/d` (deploy), `/l` (logs), `/fix`, `/ship`, `/review`.
+- Workspace lifecycle: `/provision`, `/destroy`, `/update`, `/backup`, `/workspace`, `/tailscale`.
+```
+
+- [ ] **Step 5.2: Edit the file to add the nudge**
+
+Replace:
+```
+## Tools available
+
+- Standard dev tools: `git`, `gh`, `docker`, `node`, `python`, `ripgrep`, `fzf`, `jq`, `aws`.
+- Mobile-friendly slash commands: `/s` (status), `/d` (deploy), `/l` (logs), `/fix`, `/ship`, `/review`.
+- Workspace lifecycle: `/provision`, `/destroy`, `/update`, `/backup`, `/workspace`, `/tailscale`.
+```
+
+with:
+```
+## Tools available
+
+- Standard dev tools: `git`, `gh`, `docker`, `node`, `python`, `ripgrep`, `fzf`, `jq`, `aws`.
+- Mobile-friendly slash commands: `/s` (status), `/d` (deploy), `/l` (logs), `/fix`, `/ship`, `/review`.
+- Workspace lifecycle: `/provision`, `/destroy`, `/update`, `/backup`, `/workspace`, `/tailscale`.
+
+### GitHub operations
+
+- Prefer the `github` MCP server's tool calls (e.g. `mcp__github__*`) over shell `gh api` / `gh pr` / `gh issue` / `gh repo` when both are available — typed inputs, less token overhead, structured errors.
+- Keep using `gh` for `gh aw`, `gh auth`, and provisioning-script contexts where no MCP equivalent exists.
+- MCP is active only when `GITHUB_PERSONAL_ACCESS_TOKEN` is set; session launch auto-exports from `gh auth token`. If MCP is inactive, fall back to `gh` silently.
+```
+
+- [ ] **Step 5.3: Confirm the edit landed**
+
+Run:
+```bash
+grep -c "GitHub operations" scripts/runtime/claude-global.md
+```
+
+Expected: `1`.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add scripts/runtime/claude-global.md
+git commit -m "Add GitHub MCP preference rule to global CLAUDE.md template"
+```
+
+---
+
+## Task 6: End-to-end verification
+
+**Files:** none modified — read-only verification.
+
+- [ ] **Step 6.1: Run the full test suite**
+
+Run:
+```bash
+bash tests/run.sh
+```
+
+Expected: all tests pass, including the new `test-gh-mcp-env.sh` (3 tests) and all existing tests (no regressions).
+
+- [ ] **Step 6.2: Static review — diff summary**
+
+Run:
+```bash
+git log --oneline HEAD~5..HEAD
+git diff --stat HEAD~5..HEAD
+```
+
+Expected output (5 commits, ~6 files touched including the new test and script):
+```
+Add GitHub MCP preference rule to global CLAUDE.md template
+Source gh-mcp-env.sh in host-mode workspace launch
+Source gh-mcp-env.sh before claude in portable-mode launches
+Install gh-mcp-env.sh into ~/.claude/ during provision
+Add gh-mcp-env.sh to export GITHUB_PERSONAL_ACCESS_TOKEN from gh auth
+
+ docs/superpowers/plans/2026-04-20-github-mcp-default.md    | +NNN
+ docs/superpowers/specs/2026-04-20-github-mcp-default-design.md | +NNN
+ scripts/deploy/install.sh                                  |   6 +++
+ scripts/portable/start-claude-portable.sh                  |   4 +-
+ scripts/runtime/claude-global.md                           |   6 +++
+ scripts/runtime/gh-mcp-env.sh                              |  15 +++++
+ scripts/runtime/start-claude.sh                            |   2 +-
+ tests/test-gh-mcp-env.sh                                   |  60 +++++++++
+```
+
+Plan/spec diff counts will vary; the other file counts should match within +/- a couple of lines.
+
+- [ ] **Step 6.3: Manual smoke test (in a real provisioned workspace)**
+
+Can be deferred to after merge. Sequence:
+1. Run `scripts/deploy/install.sh` (or provision a fresh workspace via `/provision`) so `~/.claude/gh-mcp-env.sh` exists inside the container.
+2. Via the login menu, pick a repo to launch.
+3. In the launched Claude session, ask it: `echo "$GITHUB_PERSONAL_ACCESS_TOKEN" | head -c 10` — expect `gho_` or `ghu_` prefix (gh OAuth token shape).
+4. Ask Claude: "list my open PRs on this repo." Confirm the tool call is `mcp__github__*` rather than `bash` running `gh pr list`.
+5. Negative test: in the container, run `gh auth logout`, then relaunch a session. Confirm the stderr hint `ℹ GitHub MCP inactive — run 'gh auth login' to enable agent GitHub tools` prints once during launch, and the session still starts cleanly.
+
+Outcome: if all the above hold, the change is production-ready. If step 4 shows Claude still shelling out to `gh`, check that the global CLAUDE.md nudge is actually being loaded (it's injected from `~/.claude/CLAUDE.md`, which `install.sh` creates from `scripts/runtime/claude-global.md` only if the file doesn't already exist — existing workspaces with a hand-edited CLAUDE.md won't auto-pick-up the nudge).
+
+- [ ] **Step 6.4: No commit required** — verification only.
+
+---
+
+## Self-Review Notes
+
+Ran through the completed plan against the spec:
+
+**Spec coverage:**
+- "gh-mcp-env.sh" section → Task 1 ✓
+- "Install path" section → Task 2 ✓
+- "Launch script integration" table (3 of 4 launches) → Tasks 3 and 4 ✓
+- "Guidance in global CLAUDE.md" section → Task 5 ✓
+- "Testing" section (smoke, graceful degradation, in-container consistency) → Task 6, steps 6.1/6.3 ✓
+- "Rollback" and "Follow-ups" sections → no tasks needed (documented only)
+
+**Placeholder scan:** None — every step has concrete code, exact commands, and expected output.
+
+**Type consistency:** File paths are consistent throughout (`scripts/runtime/gh-mcp-env.sh`, `~/.claude/gh-mcp-env.sh`, `tests/test-gh-mcp-env.sh`). Test function names are internally consistent. The env var name `GITHUB_PERSONAL_ACCESS_TOKEN` matches the plugin's `.mcp.json` expectation.

--- a/docs/superpowers/specs/2026-04-20-github-mcp-default-design.md
+++ b/docs/superpowers/specs/2026-04-20-github-mcp-default-design.md
@@ -1,0 +1,123 @@
+# GitHub MCP as default for agent-driven GitHub ops
+
+## Problem
+
+Claude sessions spawned inside a `dev-env` workspace reach for `gh api` / `gh pr` / `gh issue` shell commands when doing GitHub work. This is token-expensive (verbose JSON, shell framing) and brittle (ad-hoc `--jq` filtering, stderr parsing for errors).
+
+GitHub's official remote MCP server at `https://api.githubcopilot.com/mcp/` exposes the same operations as typed tool calls. The `github` plugin from the `claude-plugins-official` marketplace is already installed in this workspace, but dormant because its `.mcp.json` requires `GITHUB_PERSONAL_ACCESS_TOKEN` to be set in the environment and nothing in the workspace sets it.
+
+## Goal
+
+Make the github MCP active by default in every Claude session launched via the workspace login menu, reusing the user's existing `gh` CLI auth state so no new secret/token has to be provisioned. Nudge future agents to prefer MCP tools over shell `gh` calls for agent-driven operations.
+
+## Non-goals
+
+- Provisioning a separate GitHub PAT in SSM or any other secret store
+- Running a local GitHub MCP server (Docker image) — remote hosted server is sufficient
+- Migrating the provisioning scripts (`install.sh`, `setup-auth.sh`, `onboarding-prompt.txt`) off `gh` — these run before Claude exists
+- Replacing `gh aw` or `gh auth` invocations — no MCP equivalent
+- Rewriting existing slash commands (`.claude/commands/review.md`, `ship.md`, `s.md`) that shell out to `gh` — tracked as a follow-up after MCP is validated in real use
+
+## Design
+
+### Single source of truth: `scripts/runtime/gh-mcp-env.sh`
+
+A small sourceable script installed into the container and sourced by every Claude launch path.
+
+```bash
+#!/usr/bin/env bash
+# Export GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state so the github MCP
+# server (https://api.githubcopilot.com/mcp/) activates for the Claude session.
+# No-op (with stderr hint) if gh isn't installed or isn't authed.
+if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+  export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+else
+  echo "ℹ GitHub MCP inactive — run 'gh auth login' to enable agent GitHub tools" >&2
+fi
+```
+
+Guard rationale (matches existing house style in `install.sh`):
+
+- `command -v gh` — handles "gh not installed"
+- `gh auth status` — handles "gh installed but not authed" (exits non-zero)
+- Short-circuit `&&` means the export line only runs when both checks pass; nothing is ever set to an empty string
+- No `set -e` interaction — the `if` condition itself consumes the exit status
+
+### Install path
+
+`scripts/deploy/install.sh` copies `scripts/runtime/gh-mcp-env.sh` to `/home/dev/.claude/gh-mcp-env.sh` during provisioning, alongside the other claude config files (`statusline-command.sh`, etc.).
+
+Ownership: `dev:dev`, mode `0755`.
+
+### Launch script integration
+
+Two launch scripts, two launches each. Three of the four launches run Claude *inside* the container and get the source line; the fourth (host-mode manager) runs Claude on the host and is intentionally left alone.
+
+| Script | Launch | Runs Claude where? | Gets source? |
+|---|---|---|---|
+| `scripts/runtime/start-claude.sh` (host-mode) | workspace (line 372) | in container via `docker exec` | **yes** |
+| `scripts/runtime/start-claude.sh` (host-mode) | manager (line 388) | on the host | **no** |
+| `scripts/portable/start-claude-portable.sh` | workspace (line 158) | in container (already) | **yes** |
+| `scripts/portable/start-claude-portable.sh` | manager (line 170) | in container (already) | **yes** |
+
+Why the host-mode manager is skipped: it runs `bash -lc 'cd ... && exec claude'` directly on the EC2 host. The host doesn't install `gh`, doesn't maintain `gh auth` state, and `~/.claude/gh-mcp-env.sh` on the host is a separate filesystem from the container's. The host-mode manager is used for workspace lifecycle management (provisioning, updates) — not for agent-driven GitHub work that benefits from MCP. Keeping it untouched avoids a cross-environment complication with no real upside.
+
+**Three concrete hunks (illustrative — exact escaping in implementation):**
+
+`scripts/runtime/start-claude.sh` line 372:
+```bash
+"docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'source ~/.claude/gh-mcp-env.sh && exec claude'"
+```
+
+`scripts/portable/start-claude-portable.sh` line 158:
+```bash
+"bash -lc 'cd \"$selected\" && source ~/.claude/gh-mcp-env.sh && exec claude'"
+```
+
+`scripts/portable/start-claude-portable.sh` line 170:
+```bash
+exec tmux new-session -A -s "claude-manager" \
+  "bash -lc 'cd \"$dir\" && source ~/.claude/gh-mcp-env.sh && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
+```
+
+### Guidance in global CLAUDE.md
+
+`scripts/runtime/claude-global.md` (the template that `install.sh` copies to `~/.claude/CLAUDE.md` at provision) gets a short rule under a new or existing section on tool preferences:
+
+> **GitHub operations**: prefer the `github` MCP server's tool calls over shell `gh api` / `gh pr` / `gh issue` / `gh repo` when both are available — typed inputs, less token overhead, structured errors. Keep using `gh` for `gh aw`, `gh auth`, and provisioning-script contexts where no MCP equivalent exists.
+
+Kept deliberately short (3 lines, no code examples, no tables) so it doesn't bloat the context-injected CLAUDE.md.
+
+## Behavior matrix
+
+| State | `GITHUB_PERSONAL_ACCESS_TOKEN` | GitHub MCP | Agent GitHub ops |
+|---|---|---|---|
+| `gh` installed + authed | set to `gh auth token` output | active | MCP tools preferred per CLAUDE.md |
+| `gh` not installed | unset | inactive | falls back to `gh` shell (which is also missing — user would see standard shell errors) |
+| `gh` installed but not authed | unset; stderr hint emitted | inactive | falls back to `gh` shell (also unauthed — standard `gh` errors) |
+| Token rejected by `api.githubcopilot.com/mcp/` (e.g. OAuth-shaped token not accepted) | set, but MCP fails on first call | effectively inactive | agent falls back to `gh` shell on error |
+
+The last row is the one unverified assumption — GitHub's remote MCP endpoint may or may not accept `gh`-OAuth-shaped tokens. If it rejects them, behavior degrades gracefully (agent falls back to `gh`), but MCP won't activate. The fallback path is "Option A" from the original brainstorm: user creates an explicit PAT and stores it in SSM. Tracked as a follow-up if needed.
+
+## Failure modes and error handling
+
+- **Launch script aborted by source failure**: not possible — `gh-mcp-env.sh` has no `set -e`, and its only failure path is the conditional's else branch (which just echoes).
+- **`gh auth token` slow**: measured ~10-20ms on this container; negligible for a once-per-session cost.
+- **Token leaks into child processes**: yes, by design — that's how the MCP server reads it. Container is single-user and sandboxed; not a concern in this environment. Users running `ps aux` or `env` in their own shell will see the token. CLAUDE.md already notes this container's low-security-boundary model.
+- **Token rotation**: if the user re-runs `gh auth login`, the next launched Claude session automatically picks up the new token. No restart or explicit refresh needed.
+
+## Testing
+
+- **Smoke**: launch a session via the menu, ask Claude to list PRs on a repo. If MCP is active, the tool call appears as `mcp__github__*`; if inactive, Claude runs `gh pr list`.
+- **Graceful degradation**: uninstall or un-auth `gh`, re-launch the menu, confirm stderr hint appears and Claude still starts cleanly.
+- **In-container session consistency**: `env | grep GITHUB_PERSONAL_ACCESS_TOKEN` should return a value in both workspace and portable-mode manager sessions; the host-mode manager intentionally won't (documented, not a bug).
+
+## Rollback
+
+Single-file: revert the four launch-script hunks and delete `gh-mcp-env.sh`. The `claude-global.md` guidance line is additive and can stay or be dropped independently.
+
+## Follow-ups (out of scope for this spec)
+
+- Audit and migrate existing `gh`-using slash commands (`.claude/commands/review.md`, `ship.md`, `s.md`) to prefer MCP tool calls — once MCP is confirmed to work in real usage.
+- If `api.githubcopilot.com/mcp/` rejects `gh`-shaped OAuth tokens, design a PAT-in-SSM path (the brainstorm's Option A) as a fallback.
+- Add an integration test that exercises at least one MCP tool call at session start so we notice quickly if the remote endpoint changes.

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -342,14 +342,6 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     chmod +x ~/.claude/statusline-command.sh
     ok "Installed statusline-command.sh"
 
-    # GitHub MCP auth bridge — sourced by start-claude*.sh to export
-    # GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state.
-    if [[ -f "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ]]; then
-        cp "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ~/.claude/gh-mcp-env.sh
-        chmod +x ~/.claude/gh-mcp-env.sh
-        ok "Installed gh-mcp-env.sh"
-    fi
-
     # Build desired user-scope settings
     desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"},"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}'
 
@@ -377,6 +369,14 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
         echo "$desired" | jq . > ~/.claude/settings.json
         ok "Created settings.json with default settings"
     fi
+fi
+
+# GitHub MCP auth bridge — sourced by start-claude*.sh to export
+# GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state.
+if [[ -f "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ]]; then
+    cp "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ~/.claude/gh-mcp-env.sh
+    chmod +x ~/.claude/gh-mcp-env.sh
+    ok "Installed gh-mcp-env.sh"
 fi
 
 # Global CLAUDE.md — user-scope instructions shared across all projects.

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -342,6 +342,14 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     chmod +x ~/.claude/statusline-command.sh
     ok "Installed statusline-command.sh"
 
+    # GitHub MCP auth bridge — sourced by start-claude*.sh to export
+    # GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state.
+    if [[ -f "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ]]; then
+        cp "$DEV_ENV/scripts/runtime/gh-mcp-env.sh" ~/.claude/gh-mcp-env.sh
+        chmod +x ~/.claude/gh-mcp-env.sh
+        ok "Installed gh-mcp-env.sh"
+    fi
+
     # Build desired user-scope settings
     desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"},"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}'
 

--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -155,7 +155,7 @@ launch() {
 
     # Run Claude Code directly — we are already inside the container
     exec tmux new-session -A -s "$session_name" \
-        "bash -lc 'cd \"$selected\" && exec claude'"
+        "bash -lc 'cd \"$selected\" && source ~/.claude/gh-mcp-env.sh && exec claude'"
 }
 
 # --- Launch Claude Code for workspace management ---
@@ -167,7 +167,7 @@ launch_manager() {
     echo ""
 
     exec tmux new-session -A -s "claude-manager" \
-        "bash -lc 'cd \"$dir\" && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
+        "bash -lc 'cd \"$dir\" && source ~/.claude/gh-mcp-env.sh && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
 }
 
 # --- Launch a shell in tmux ---

--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -155,7 +155,7 @@ launch() {
 
     # Run Claude Code directly — we are already inside the container
     exec tmux new-session -A -s "$session_name" \
-        "bash -lc 'cd \"$selected\" && source ~/.claude/gh-mcp-env.sh && exec claude'"
+        "bash -lc 'cd \"$selected\" && source ~/.claude/gh-mcp-env.sh; exec claude'"
 }
 
 # --- Launch Claude Code for workspace management ---
@@ -167,7 +167,7 @@ launch_manager() {
     echo ""
 
     exec tmux new-session -A -s "claude-manager" \
-        "bash -lc 'cd \"$dir\" && source ~/.claude/gh-mcp-env.sh && exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
+        "bash -lc 'cd \"$dir\" && source ~/.claude/gh-mcp-env.sh; exec claude --append-system-prompt-file \"$MANAGER_PROMPT\" \"Greet me and show what you can help with.\"'"
 }
 
 # --- Launch a shell in tmux ---

--- a/scripts/runtime/claude-global.md
+++ b/scripts/runtime/claude-global.md
@@ -22,6 +22,12 @@ Applies to every project in this workspace. Edit freely — this file is only in
 - Mobile-friendly slash commands: `/s` (status), `/d` (deploy), `/l` (logs), `/fix`, `/ship`, `/review`.
 - Workspace lifecycle: `/provision`, `/destroy`, `/update`, `/backup`, `/workspace`, `/tailscale`.
 
+### GitHub operations
+
+- Prefer the `github` MCP server's tool calls (e.g. `mcp__github__*`) over shell `gh api` / `gh pr` / `gh issue` / `gh repo` when both are available — typed inputs, less token overhead, structured errors.
+- Keep using `gh` for `gh aw`, `gh auth`, and provisioning-script contexts where no MCP equivalent exists.
+- MCP is active only when `GITHUB_PERSONAL_ACCESS_TOKEN` is set; session launch auto-exports from `gh auth token`. If MCP is inactive, fall back to `gh` silently.
+
 ## Communication defaults
 
 - Terse. Lead with the answer. Skip recap and filler.

--- a/scripts/runtime/gh-mcp-env.sh
+++ b/scripts/runtime/gh-mcp-env.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# gh-mcp-env.sh — Exports GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state so
+# the github MCP server (https://api.githubcopilot.com/mcp/) activates for the
+# Claude session. No-op (with a one-line stderr hint) if gh isn't installed or
+# isn't authed.
+#
+# Sourced by start-claude*.sh just before exec'ing claude.
+#
+# Safe to source under `set -e`: the conditional consumes the exit status, so a
+# missing or unauthed gh never aborts the caller.
+
+if command -v gh &>/dev/null && gh auth status &>/dev/null; then
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+else
+    echo "ℹ GitHub MCP inactive — run 'gh auth login' to enable agent GitHub tools" >&2
+fi

--- a/scripts/runtime/gh-mcp-env.sh
+++ b/scripts/runtime/gh-mcp-env.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 # gh-mcp-env.sh — Exports GITHUB_PERSONAL_ACCESS_TOKEN from gh CLI auth state so
 # the github MCP server (https://api.githubcopilot.com/mcp/) activates for the
-# Claude session. No-op (with a one-line stderr hint) if gh isn't installed or
-# isn't authed.
+# Claude session. No-op (with a one-line stderr hint) if gh isn't installed,
+# isn't authed, or returns an empty token.
 #
 # Sourced by start-claude*.sh just before exec'ing claude.
 #
-# Safe to source under `set -e`: the conditional consumes the exit status, so a
-# missing or unauthed gh never aborts the caller.
+# Safe to source under `set -e`: every failure path flows through an `if`
+# conditional that consumes the exit status, so the caller is never aborted.
 
 if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-    export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token 2>/dev/null)"
+    _gh_mcp_token="$(gh auth token 2>/dev/null || true)"
+    if [[ -n "$_gh_mcp_token" ]]; then
+        export GITHUB_PERSONAL_ACCESS_TOKEN="$_gh_mcp_token"
+    else
+        echo "info: GitHub MCP inactive - 'gh auth token' returned nothing; try 'gh auth refresh'" >&2
+    fi
+    unset _gh_mcp_token
 else
-    echo "ℹ GitHub MCP inactive — run 'gh auth login' to enable agent GitHub tools" >&2
+    echo "info: GitHub MCP inactive - run 'gh auth login' to enable agent GitHub tools" >&2
 fi

--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -369,7 +369,7 @@ launch() {
     echo ""
 
     tmux new-session -A -s "$session_name" \
-        "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'exec claude'"
+        "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'source ~/.claude/gh-mcp-env.sh; exec claude'"
 }
 
 # --- Launch Claude Code on the host (for workspace management / updates) ---

--- a/tests/test-gh-mcp-env.sh
+++ b/tests/test-gh-mcp-env.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Tests for scripts/runtime/gh-mcp-env.sh
+
+GH_MCP_ENV_SCRIPT="$REPO_ROOT/scripts/runtime/gh-mcp-env.sh"
+
+# Run the script in a subshell that:
+#   - starts from a clean env (no GITHUB_PERSONAL_ACCESS_TOKEN)
+#   - has PATH=$TEST_DIR/bin (no real gh leaks in)
+# Prints: <token-or-UNSET> on stdout, preserves script stderr
+_run_env_script() {
+    (
+        unset GITHUB_PERSONAL_ACCESS_TOKEN
+        export PATH="$TEST_DIR/bin"
+        source "$GH_MCP_ENV_SCRIPT" 2>"$TEST_DIR/stderr"
+        echo "${GITHUB_PERSONAL_ACCESS_TOKEN:-UNSET}"
+    )
+}
+
+_stderr() {
+    cat "$TEST_DIR/stderr" 2>/dev/null || true
+}
+
+test_gh_missing_no_export_with_hint() {
+    # No gh binary on PATH (TEST_DIR/bin is empty)
+    local result
+    result=$(_run_env_script)
+    assert_eq "UNSET" "$result"
+    assert_contains "$(_stderr)" "GitHub MCP inactive"
+    assert_contains "$(_stderr)" "gh auth login"
+}
+
+test_gh_installed_but_unauthed_no_export_with_hint() {
+    # gh exists but `gh auth status` exits non-zero
+    cat > "$TEST_DIR/bin/gh" <<'MOCK'
+#!/bin/bash
+case "$1 $2" in
+    "auth status") echo "not logged in" >&2; exit 1 ;;
+    *) exit 1 ;;
+esac
+MOCK
+    chmod +x "$TEST_DIR/bin/gh"
+
+    local result
+    result=$(_run_env_script)
+    assert_eq "UNSET" "$result"
+    assert_contains "$(_stderr)" "GitHub MCP inactive"
+}
+
+test_gh_authed_exports_token_silently() {
+    # gh is authed and `gh auth token` prints a token
+    cat > "$TEST_DIR/bin/gh" <<'MOCK'
+#!/bin/bash
+case "$1 $2" in
+    "auth status") exit 0 ;;
+    "auth token") echo "gho_testtoken123" ;;
+    *) exit 0 ;;
+esac
+MOCK
+    chmod +x "$TEST_DIR/bin/gh"
+
+    local result
+    result=$(_run_env_script)
+    assert_eq "gho_testtoken123" "$result"
+    # Hint must NOT appear when MCP successfully activates
+    local stderr
+    stderr=$(_stderr)
+    if [[ "$stderr" == *"GitHub MCP inactive"* ]]; then
+        _fail "stderr unexpectedly contained hint: $stderr"
+    fi
+}

--- a/tests/test-gh-mcp-env.sh
+++ b/tests/test-gh-mcp-env.sh
@@ -46,6 +46,24 @@ MOCK
     assert_contains "$(_stderr)" "GitHub MCP inactive"
 }
 
+test_gh_authed_but_token_empty_no_export_with_hint() {
+    # gh auth status succeeds but gh auth token prints nothing
+    cat > "$TEST_DIR/bin/gh" <<'MOCK'
+#!/bin/bash
+case "$1 $2" in
+    "auth status") exit 0 ;;
+    "auth token") exit 0 ;;  # No output, clean exit
+    *) exit 0 ;;
+esac
+MOCK
+    chmod +x "$TEST_DIR/bin/gh"
+
+    local result
+    result=$(_run_env_script)
+    assert_eq "UNSET" "$result"
+    assert_contains "$(_stderr)" "returned nothing"
+}
+
 test_gh_authed_exports_token_silently() {
     # gh is authed and `gh auth token` prints a token
     cat > "$TEST_DIR/bin/gh" <<'MOCK'


### PR DESCRIPTION
## Summary
- Activates the already-installed `github` MCP plugin (`https://api.githubcopilot.com/mcp/`) by default in every Claude session launched inside the dev-env container
- Reuses the user's `gh` CLI auth — boot scripts export `GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)"` via a new guarded script sourced before `exec claude`
- Adds a short nudge to the global CLAUDE.md template so agents prefer MCP tool calls (`mcp__github__*`) over shell `gh api` / `gh pr` / `gh issue` for agent-driven GitHub work

## Why
`gh api` / `gh pr` / `gh issue` shell calls are token-heavy and brittle for agents. The `github` MCP plugin was already installed via the official marketplace but dormant because `GITHUB_PERSONAL_ACCESS_TOKEN` was unset. This PR wires the activation without introducing a new secret.

## Files changed
- `scripts/runtime/gh-mcp-env.sh` (new) — guarded export: `command -v gh && gh auth status`, then `export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)"`, else stderr hint. Safe under `set -e`. Handles empty-token edge case (auth status passes but token empty).
- `tests/test-gh-mcp-env.sh` (new) — 4 tests covering gh-missing / gh-unauthed / token-empty / happy path. All PASS.
- `scripts/deploy/install.sh` — copies `gh-mcp-env.sh` into `~/.claude/` during provision, as its own top-level block (hoisted out of the statusline install per review feedback).
- `scripts/portable/start-claude-portable.sh` — both in-container launches (workspace + manager) source the env script before `exec claude` using fail-open `;` separator (missing env script won't abort the session).
- `scripts/runtime/start-claude.sh` — host-mode workspace launch (line 372) also sources. Host-mode manager (line 388) intentionally untouched — runs Claude on the host where `gh` state isn't available.
- `scripts/runtime/claude-global.md` — 3-bullet rule under `## Tools available` telling agents to prefer MCP over `gh api/pr/issue/repo` with `gh aw` and `gh auth` carve-outs.

## Design doc
- Spec: `docs/superpowers/specs/2026-04-20-github-mcp-default-design.md`
- Plan: `docs/superpowers/plans/2026-04-20-github-mcp-default.md`

## Notable deviations from the plan (caught in review)
- **Empty-token hardening** — if `gh auth status` passes but `gh auth token` returns empty, the original plan would have exported `GITHUB_PERSONAL_ACCESS_TOKEN=""`, activating MCP with an empty bearer. Commit `8c9da37` adds a non-empty check with a distinct hint (`try 'gh auth refresh'`).
- **Hoisted install** — plan had the new `install.sh` block nested inside the statusline `if`. Commit `f0c9ab0` hoists it to top level so the two installs are independent.
- **Fail-open launch** — plan used `source X && exec claude`. Commit `dd55622` (and Task 4 arriving `104ff2f`) use `;` instead so a missing env script doesn't brick the session — MCP just stays inactive, matching the spec's "silently dormant" policy.

## Test plan
- [x] `bash tests/run.sh tests/test-gh-mcp-env.sh` — 4/4 PASS
- [x] `bash tests/run.sh tests/test-start-claude.sh` — 29/29 PASS, no regression
- [ ] After merge: provision or update a workspace, launch a session via the menu, verify `echo "$GITHUB_PERSONAL_ACCESS_TOKEN" | head -c 4` returns `gho_` (or similar), ask Claude to list PRs, confirm tool call is `mcp__github__*` rather than shell `gh pr list`
- [ ] Negative: `gh auth logout` inside the container, relaunch a session, confirm stderr hint prints and session still starts

## Not covered (intentional follow-ups)
- Migrating existing `gh`-using slash commands in `.claude/commands/` (review.md, ship.md, s.md) to MCP — deferred until real MCP usage validates the path
- `onboarding.sh:46` uses the same launch pattern but skipped for now (gh auth isn't set up at first-run)
- PAT-in-SSM fallback if GitHub's remote MCP rejects `gh`-OAuth-shaped tokens — add if/when observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)