### PR TITLE
[codex] Add host schedule bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ All lifecycle operations run from inside a Claude Code session in this repo:
 | `/update` | Apply updates to a running workspace |
 | `/tailscale` | Set up Tailscale for private SSH |
 | `/workspace` | Manage repos and git worktrees |
+| `/host-schedule` | Schedule one-off or recurring container commands through the host |
 
 The lifecycle control plane is still Claude-based for now. Codex is supported inside the provisioned workspace for repo work, onboarding, and SSH-launched coding sessions.
 
@@ -107,6 +108,7 @@ Your Mac / Phone / Tablet
               │    ├── Git, GitHub CLI, AWS CLI
               │    └── Your project repos
               ├── tmux (session persistence)
+              ├── host scheduling bridge (container → atd)
               └── Workspace picker on SSH connect
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,12 @@ services:
       # AWS CLI config/credentials (shared between host and container)
       - ~/.aws:/home/dev/.aws
 
+      # Host scheduling bridge. Container sessions can submit requests, but
+      # status/logs are read-only and jobs are created in host-only paths.
+      - ~/.always-on-claude/schedule/inbox:/home/dev/.aoc/schedule/inbox
+      - ~/.always-on-claude/schedule/status:/home/dev/.aoc/schedule/status:ro
+      - ~/.always-on-claude/schedule/logs:/home/dev/.aoc/schedule/logs:ro
+
       # SSH keys for GitHub (read-only)
       - ~/.ssh:/home/dev/.ssh:ro
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,6 +141,17 @@ Each workspace gets its own named tmux session:
 Sessions run on the **host** (not inside the container), so they survive container restarts. The selected coding assistant runs inside the container via `docker exec`.
 The workspace manager remains Claude-based because lifecycle commands still live in `.claude/commands/`.
 
+### Schedule bridge
+
+Provisioned hosts install a narrow scheduling bridge for container coding sessions:
+
+- Container writes request JSON to `/home/dev/.aoc/schedule/inbox`.
+- Host `always-on-claude-schedule-bridge.path` watches `~/.always-on-claude/schedule/inbox/*.json`.
+- Host processor validates the request, submits a host `atd` job or managed user crontab entry, and stores status/logs under `~/.always-on-claude/schedule/`.
+- The scheduled host job runs the command back inside the dev container with `docker compose exec -T -w <cwd> dev bash -lc <command>`.
+
+Only the inbox is writable from the container. Status and logs are mounted read-only, and generated `at` job scripts live in host-only paths.
+
 ### Login flow
 
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -127,12 +127,13 @@ curl -fsSL https://raw.githubusercontent.com/verkyyi/always-on-claude/main/scrip
 8. **Settings**: Generates `~/.claude/settings.json` with permission bypass, status line, MCP servers
 9. **Heartbeat hooks**: If `AOC_HEARTBEAT_URL` + `AOC_HEARTBEAT_TOKEN` set, adds webhook hooks for Notification (idle), Stop, and SessionStart events
 10. **tmux config**: Installs `~/.tmux.conf` and `~/.tmux-status.sh`
-11. **SSH config**: Accepts `NO_CLAUDE` env var. Optional password auth via `AOC_SSH_PASSWORD`
-12. **Shell integration**: Adds `ssh-login.sh` to `.bash_profile`
-13. **Auto-updater**: Installs systemd timer via `install-updater.sh`
-14. **CloudWatch alarms**: Memory warning (>80%) and critical (>90%) alarms via SNS
-15. **Docker**: Pulls image, starts container, fixes permissions
-16. **Provisioned marker**: Writes `~/dev-env/.provisioned` with timestamp and commit
+11. **Schedule bridge**: Installs host `atd`, cron, and a systemd path/service that accepts container schedule requests
+12. **SSH config**: Accepts `NO_CLAUDE` env var. Optional password auth via `AOC_SSH_PASSWORD`
+13. **Shell integration**: Adds `ssh-login.sh` to `.bash_profile`
+14. **Auto-updater**: Installs systemd timer via `install-updater.sh`
+15. **CloudWatch alarms**: Memory warning (>80%) and critical (>90%) alarms via SNS
+16. **Docker**: Pulls image, starts container, fixes permissions
+17. **Provisioned marker**: Writes `~/dev-env/.provisioned` with timestamp and commit
 
 ### Auth setup (first SSH login)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -197,6 +197,7 @@ Run from a Claude session in the always-on-claude repo:
 | `/tailscale` | Set up Tailscale for private SSH access |
 | `/workspace` | Manage repos and git worktrees |
 | `/backup` | EBS snapshot management (create/list/restore/prune) |
+| `/schedule` | Schedule container commands through the host `atd` bridge |
 
 ### Mobile-friendly commands
 
@@ -210,6 +211,19 @@ Short aliases designed for phone typing:
 | `/fix` | Find failing tests, fix them, commit |
 | `/ship` | Merge PR, deploy, verify health |
 | `/review` | Summarize open PRs, approve/merge |
+
+### Scheduled jobs
+
+Container coding sessions do not get direct host `at` or cron access. Use `/host-schedule` in Claude or the Codex `schedule-host-job` skill to submit jobs through the host bridge. `/schedule` may resolve to Claude's built-in scheduling feature, so `/host-schedule` is the reliable workspace command:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "03:00 tomorrow" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh cron "0 3 * * *" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh list
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh logs <job-id>
+```
+
+The host validates requests, stores status/logs in `~/.always-on-claude/schedule/`, and runs the command inside the container at the requested time. Recurring jobs are stored as managed blocks in the `dev` user's host crontab and can be removed with `aoc-schedule.sh cancel <job-id>`.
 
 ### How slash commands work
 

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -409,6 +409,16 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     fi
 fi
 
+# Claude user-scope commands managed by this repo.
+if [[ -x "$DEV_ENV/scripts/runtime/sync-claude-personalization.sh" ]]; then
+    claude_setup_status=$("$DEV_ENV/scripts/runtime/sync-claude-personalization.sh")
+    if [[ "$claude_setup_status" == "updated" ]]; then
+        ok "Updated Claude home state"
+    else
+        skip "Claude home state"
+    fi
+fi
+
 # Global CLAUDE.md — user-scope instructions shared across all projects.
 # Install once if missing; leave user edits alone on re-runs.
 if [[ -f "$DEV_ENV/scripts/runtime/claude-global.md" ]]; then
@@ -613,6 +623,13 @@ ok "Systemd service installed and enabled"
 
 step="chmod scripts"
 chmod +x "$DEV_ENV"/scripts/deploy/*.sh "$DEV_ENV"/scripts/runtime/*.sh 2>/dev/null || true
+
+if [[ -x "$DEV_ENV/scripts/runtime/install-schedule-bridge.sh" ]]; then
+    step="schedule bridge"
+    bash "$DEV_ENV/scripts/runtime/install-schedule-bridge.sh"
+else
+    skip "schedule bridge script not found"
+fi
 
 # --- Docker pull + start ----------------------------------------------------
 

--- a/scripts/portable/entrypoint.sh
+++ b/scripts/portable/entrypoint.sh
@@ -78,6 +78,14 @@ if [[ -f /home/dev/dev-env/scripts/runtime/tmux-status.sh ]]; then
     chmod +x /home/dev/.tmux-status.sh
 fi
 
+# Repo-managed user-scope assistant state
+if [[ -x /home/dev/dev-env/scripts/runtime/sync-claude-personalization.sh ]]; then
+    HOME=/home/dev /home/dev/dev-env/scripts/runtime/sync-claude-personalization.sh >/dev/null || true
+fi
+if [[ -x /home/dev/dev-env/scripts/runtime/sync-codex-personalization.sh ]]; then
+    HOME=/home/dev /home/dev/dev-env/scripts/runtime/sync-codex-personalization.sh >/dev/null || true
+fi
+
 # Fix ownership on everything
 chown -R dev:dev /home/dev/.claude /home/dev/.codex \
     /home/dev/.config /home/dev/projects /home/dev/overnight \

--- a/scripts/runtime/aoc-schedule.sh
+++ b/scripts/runtime/aoc-schedule.sh
@@ -1,0 +1,397 @@
+#!/bin/bash
+# aoc-schedule.sh — Submit scheduled container jobs to the host bridge.
+#
+# Intended to run inside the dev container. It writes request JSON into a
+# bind-mounted inbox; a host-side systemd path unit validates and submits the
+# job to the host atd service.
+
+set -euo pipefail
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage:
+  aoc-schedule at <time-spec> [--cwd <container-path>] [--label <name>] -- <command>
+  aoc-schedule cron <5-field-spec> [--cwd <container-path>] [--label <name>] -- <command>
+  aoc-schedule list
+  aoc-schedule status <job-id>
+  aoc-schedule logs <job-id> [lines]
+  aoc-schedule cancel <job-id>
+
+Examples:
+  aoc-schedule at "now + 2 hours" -- "npm test"
+  aoc-schedule cron "0 3 * * *" -- "npm test"
+  aoc-schedule at "03:00 tomorrow" --cwd /home/dev/projects/app -- ./scripts/nightly.sh
+  aoc-schedule list
+  aoc-schedule logs 20260424T030000Z-a1b2c3d4
+EOF
+}
+
+schedule_root() {
+    if [[ -n "${AOC_SCHEDULE_DIR:-}" ]]; then
+        echo "$AOC_SCHEDULE_DIR"
+    elif [[ -d "$HOME/.aoc/schedule" || -d "$HOME/.aoc" ]]; then
+        echo "$HOME/.aoc/schedule"
+    else
+        echo "$HOME/.always-on-claude/schedule"
+    fi
+}
+
+ROOT="$(schedule_root)"
+INBOX_DIR="$ROOT/inbox"
+STATUS_DIR="$ROOT/status"
+LOG_DIR="$ROOT/logs"
+
+require_jq() {
+    command -v jq >/dev/null 2>&1 || die "jq is required"
+}
+
+require_inbox() {
+    [[ -d "$INBOX_DIR" ]] || die "Schedule bridge inbox not found at $INBOX_DIR. Run /update on the host and restart the container."
+    [[ -w "$INBOX_DIR" ]] || die "Schedule bridge inbox is not writable: $INBOX_DIR"
+}
+
+random_hex() {
+    if command -v od >/dev/null 2>&1; then
+        od -An -N4 -tx1 /dev/urandom | tr -d ' \n'
+    else
+        date +%N
+    fi
+}
+
+new_id() {
+    printf '%s-%s\n' "$(date -u +%Y%m%dT%H%M%SZ)" "$(random_hex)"
+}
+
+valid_id() {
+    [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+self_cmd() {
+    if [[ -n "${AOC_SCHEDULE_COMMAND:-}" ]]; then
+        echo "$AOC_SCHEDULE_COMMAND"
+    else
+        echo "$0"
+    fi
+}
+
+container_cwd_ok() {
+    [[ "$1" == "/home/dev/projects" || "$1" == /home/dev/projects/* ]]
+}
+
+command_from_args() {
+    if [[ $# -eq 1 ]]; then
+        printf '%s' "$1"
+        return 0
+    fi
+
+    local out="" arg
+    for arg in "$@"; do
+        printf -v out '%s%q ' "$out" "$arg"
+    done
+    printf '%s' "${out% }"
+}
+
+write_request() {
+    local id="$1"
+    local tmp="$INBOX_DIR/.${id}.tmp"
+    local dest="$INBOX_DIR/${id}.json"
+
+    umask 077
+    cat > "$tmp"
+    mv "$tmp" "$dest"
+}
+
+cmd_at() {
+    require_jq
+    require_inbox
+
+    [[ $# -ge 1 ]] || die "Missing time spec"
+
+    local time_spec="$1"
+    local cwd="$PWD"
+    local label=""
+    shift
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cwd)
+                [[ $# -ge 2 ]] || die "--cwd requires a path"
+                cwd="$2"
+                shift 2
+                ;;
+            --label)
+                [[ $# -ge 2 ]] || die "--label requires a value"
+                label="$2"
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                die "Unknown option before --: $1"
+                ;;
+        esac
+    done
+
+    [[ $# -gt 0 ]] || die "Missing command after --"
+    container_cwd_ok "$cwd" || die "Scheduled cwd must be under /home/dev/projects: $cwd"
+
+    local command id created_at
+    command="$(command_from_args "$@")"
+    id="$(new_id)"
+    created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    jq -n \
+        --arg id "$id" \
+        --arg action "at" \
+        --arg time "$time_spec" \
+        --arg cwd "$cwd" \
+        --arg command "$command" \
+        --arg job_label "$label" \
+        --arg created_at "$created_at" \
+        --arg requested_by "$(whoami 2>/dev/null || echo dev)" \
+        '{
+            version: 1,
+            id: $id,
+            action: $action,
+            time: $time,
+            cwd: $cwd,
+            command: $command,
+            "label": $job_label,
+            created_at: $created_at,
+            requested_by: $requested_by
+        }' | write_request "$id"
+
+    local self
+    self="$(self_cmd)"
+
+    echo "Submitted: $id"
+    echo "Status:    $self status $id"
+    echo "Logs:      $self logs $id"
+}
+
+cron_field_ok() {
+    [[ "$1" =~ ^[A-Za-z0-9,*/.-]+$ ]]
+}
+
+cron_spec_ok() {
+    local spec="$1"
+    local fields=()
+    read -r -a fields <<< "$spec"
+
+    [[ ${#fields[@]} -eq 5 ]] || return 1
+
+    local field
+    for field in "${fields[@]}"; do
+        cron_field_ok "$field" || return 1
+    done
+}
+
+cmd_cron() {
+    require_jq
+    require_inbox
+
+    [[ $# -ge 1 ]] || die "Missing cron spec"
+
+    local schedule="$1"
+    local cwd="$PWD"
+    local label=""
+    shift
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --cwd)
+                [[ $# -ge 2 ]] || die "--cwd requires a path"
+                cwd="$2"
+                shift 2
+                ;;
+            --label)
+                [[ $# -ge 2 ]] || die "--label requires a value"
+                label="$2"
+                shift 2
+                ;;
+            --)
+                shift
+                break
+                ;;
+            *)
+                die "Unknown option before --: $1"
+                ;;
+        esac
+    done
+
+    [[ $# -gt 0 ]] || die "Missing command after --"
+    cron_spec_ok "$schedule" || die "Cron spec must be exactly five fields using cron syntax: $schedule"
+    container_cwd_ok "$cwd" || die "Scheduled cwd must be under /home/dev/projects: $cwd"
+
+    local command id created_at
+    command="$(command_from_args "$@")"
+    id="$(new_id)"
+    created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    jq -n \
+        --arg id "$id" \
+        --arg action "cron" \
+        --arg schedule "$schedule" \
+        --arg cwd "$cwd" \
+        --arg command "$command" \
+        --arg job_label "$label" \
+        --arg created_at "$created_at" \
+        --arg requested_by "$(whoami 2>/dev/null || echo dev)" \
+        '{
+            version: 1,
+            id: $id,
+            action: $action,
+            schedule: $schedule,
+            cwd: $cwd,
+            command: $command,
+            "label": $job_label,
+            created_at: $created_at,
+            requested_by: $requested_by
+        }' | write_request "$id"
+
+    local self
+    self="$(self_cmd)"
+
+    echo "Submitted: $id"
+    echo "Status:    $self status $id"
+    echo "Logs:      $self logs $id"
+    echo "Cancel:    $self cancel $id"
+}
+
+cmd_cancel() {
+    require_jq
+    require_inbox
+
+    [[ $# -eq 1 ]] || die "Usage: aoc-schedule cancel <job-id>"
+    valid_id "$1" || die "Invalid job id: $1"
+
+    local target_id="$1"
+    local id created_at
+    id="$(new_id)"
+    created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    jq -n \
+        --arg id "$id" \
+        --arg action "cancel" \
+        --arg target_id "$target_id" \
+        --arg created_at "$created_at" \
+        --arg requested_by "$(whoami 2>/dev/null || echo dev)" \
+        '{
+            version: 1,
+            id: $id,
+            action: $action,
+            target_id: $target_id,
+            created_at: $created_at,
+            requested_by: $requested_by
+        }' | write_request "$id"
+
+    echo "Cancel requested: $target_id"
+    echo "Request id:       $id"
+}
+
+cmd_list() {
+    require_jq
+
+    [[ -d "$STATUS_DIR" ]] || die "Schedule status directory not found at $STATUS_DIR"
+
+    shopt -s nullglob
+    local files=("$STATUS_DIR"/*.json)
+    if [[ ${#files[@]} -eq 0 ]]; then
+        echo "No scheduled jobs found."
+        return 0
+    fi
+
+    jq -r '
+        [.updated_at // .created_at // "-",
+         .id // "-",
+         .status // "-",
+         .time // .schedule // "-",
+         .label // "",
+         .command // ""] | @tsv
+    ' "${files[@]}" | sort -r | while IFS=$'\t' read -r updated id status time label command; do
+        if [[ -n "$label" ]]; then
+            printf '%s  %s  %s  %s  %s\n' "$updated" "$status" "$id" "$time" "$label"
+        else
+            printf '%s  %s  %s  %s  %s\n' "$updated" "$status" "$id" "$time" "$command"
+        fi
+    done
+}
+
+cmd_status() {
+    require_jq
+    [[ $# -eq 1 ]] || die "Usage: aoc-schedule status <job-id>"
+    valid_id "$1" || die "Invalid job id: $1"
+
+    local file="$STATUS_DIR/$1.json"
+    if [[ -f "$file" ]]; then
+        jq . "$file"
+        return 0
+    fi
+
+    if [[ -f "$INBOX_DIR/$1.json" ]]; then
+        echo "Request is still queued in the container inbox."
+        jq . "$INBOX_DIR/$1.json"
+        return 0
+    fi
+
+    die "No status found for job: $1"
+}
+
+cmd_logs() {
+    [[ $# -ge 1 && $# -le 2 ]] || die "Usage: aoc-schedule logs <job-id> [lines]"
+    valid_id "$1" || die "Invalid job id: $1"
+
+    local lines="${2:-80}"
+    [[ "$lines" =~ ^[0-9]+$ ]] || die "Line count must be numeric"
+
+    local file="$LOG_DIR/$1.log"
+    [[ -f "$file" ]] || die "No log found for job: $1"
+
+    tail -n "$lines" "$file"
+}
+
+main() {
+    local cmd="${1:-}"
+    case "$cmd" in
+        at)
+            shift
+            cmd_at "$@"
+            ;;
+        cron)
+            shift
+            cmd_cron "$@"
+            ;;
+        cancel)
+            shift
+            cmd_cancel "$@"
+            ;;
+        list|"")
+            [[ -z "$cmd" ]] || shift
+            cmd_list
+            ;;
+        status)
+            shift
+            cmd_status "$@"
+            ;;
+        logs)
+            shift
+            cmd_logs "$@"
+            ;;
+        -h|--help|help)
+            usage
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/runtime/claude-home/commands/host-schedule.md
+++ b/scripts/runtime/claude-home/commands/host-schedule.md
@@ -1,0 +1,44 @@
+# Host Schedule
+
+Schedule commands from this container coding session through the always-on-claude host scheduling bridge.
+
+## Context
+
+- Arguments: $ARGUMENTS
+- Current directory: !`pwd`
+- Bridge status: !`test -d /home/dev/.aoc/schedule/inbox && test -w /home/dev/.aoc/schedule/inbox && echo ready || echo unavailable`
+
+## Usage
+
+Use this repo-managed CLI for all operations:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh
+```
+
+Parse `$ARGUMENTS` as one of:
+
+- Empty or `list`: show scheduled jobs.
+- `at <time spec> -- <command>`: schedule a one-off command from the current project directory.
+- `cron <5-field spec> -- <command>`: schedule a recurring command from the current project directory.
+- `at <time spec> --cwd <path> -- <command>`: schedule from an explicit container path under `/home/dev/projects`.
+- `status <job-id>`: show status JSON.
+- `logs <job-id> [lines]`: show recent logs.
+- `cancel <job-id>`: request cancellation of a queued host `at` job.
+
+Examples:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "now + 2 hours" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh cron "0 3 * * *" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "03:00 tomorrow" -- ./scripts/nightly.sh
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh list
+```
+
+## Rules
+
+- Prefer `/host-schedule` for this workflow. `/schedule` may resolve to Claude's built-in scheduling feature.
+- Do not call host `at`, `atrm`, `crontab`, `systemctl`, or Docker directly for this workflow from inside the container.
+- If the bridge is unavailable, tell the user to run `/update` from the manager session and restart the container so the schedule mounts are present.
+- Confirm before scheduling destructive, externally visible, cloud-costing, or long-running production actions.
+- Keep output compact: return the job id, status command, and logs command.

--- a/scripts/runtime/claude-home/commands/schedule.md
+++ b/scripts/runtime/claude-home/commands/schedule.md
@@ -1,0 +1,45 @@
+# Schedule Host Job
+
+Schedule commands from this container coding session through the always-on-claude host scheduling bridge.
+
+Note: Claude Code may reserve `/schedule` for its built-in scheduling feature. If this command is not shown, use `/host-schedule`, which is the non-conflicting user-scope skill for this bridge.
+
+## Context
+
+- Arguments: $ARGUMENTS
+- Current directory: !`pwd`
+- Bridge status: !`test -d /home/dev/.aoc/schedule/inbox && test -w /home/dev/.aoc/schedule/inbox && echo ready || echo unavailable`
+
+## Usage
+
+Use this repo-managed CLI for all operations:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh
+```
+
+Parse `$ARGUMENTS` as one of:
+
+- Empty or `list`: show scheduled jobs.
+- `at <time spec> -- <command>`: schedule a one-off command from the current project directory.
+- `cron <5-field spec> -- <command>`: schedule a recurring command from the current project directory.
+- `at <time spec> --cwd <path> -- <command>`: schedule from an explicit container path under `/home/dev/projects`.
+- `status <job-id>`: show status JSON.
+- `logs <job-id> [lines]`: show recent logs.
+- `cancel <job-id>`: request cancellation of a queued host `at` job.
+
+Examples:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "now + 2 hours" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh cron "0 3 * * *" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "03:00 tomorrow" -- ./scripts/nightly.sh
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh list
+```
+
+## Rules
+
+- Do not call host `at`, `atrm`, `crontab`, `systemctl`, or Docker directly for this workflow from inside the container.
+- If the bridge is unavailable, tell the user to run `/update` from the manager session and restart the container so the schedule mounts are present.
+- Confirm before scheduling destructive, externally visible, cloud-costing, or long-running production actions.
+- Keep output compact: return the job id, status command, and logs command.

--- a/scripts/runtime/claude-home/skills/host-schedule/SKILL.md
+++ b/scripts/runtime/claude-home/skills/host-schedule/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: host-schedule
+description: Schedule one-off or recurring cron-style commands from always-on-claude container coding sessions through the host scheduling bridge. Use when the user asks to run something later, overnight, after hours, at a specific time, or on a repeated cron cadence from a container session without direct host cron or at access.
+disable-model-invocation: true
+---
+
+# Host Schedule
+
+Schedule commands through the always-on-claude host bridge. The host validates requests, submits them to `atd`, and later runs the command back inside the `claude-dev` container.
+
+## Commands
+
+Use the repo-managed CLI:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh
+```
+
+Common operations:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "now + 2 hours" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh cron "0 3 * * *" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "03:00 tomorrow" --cwd /home/dev/projects/app -- ./scripts/nightly.sh
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh list
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh status <job-id>
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh logs <job-id>
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh cancel <job-id>
+```
+
+## Rules
+
+- Prefer `/host-schedule` for this workflow. `/schedule` may resolve to Claude's built-in scheduling feature.
+- Use `cron "<minute> <hour> <day-of-month> <month> <day-of-week>" -- <command>` for recurring jobs.
+- Use the current working directory when it is under `/home/dev/projects`; otherwise pass `--cwd /home/dev/projects/<repo>`.
+- Do not call host `at`, `atrm`, `crontab`, `systemctl`, or Docker directly from inside the container for this workflow.
+- If the bridge inbox is missing, tell the user to run `/update` in the manager session and restart the container so the schedule mounts are available.
+- Confirm before scheduling destructive, externally visible, cloud-costing, or production-impacting commands.

--- a/scripts/runtime/codex-home/skills/schedule-host-job/SKILL.md
+++ b/scripts/runtime/codex-home/skills/schedule-host-job/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: schedule-host-job
+description: Schedule one-off or recurring cron-style commands from always-on-claude container coding sessions through the host scheduling bridge. Use when the user asks Codex to run something later, overnight, "at" a time, after hours, on a repeated cron cadence, or when a container session needs host-managed scheduling without direct host shell access.
+---
+
+# Schedule Host Job
+
+Use the always-on-claude schedule bridge to submit commands from the container to the host. The host validates requests, submits them to `atd`, and later runs the command inside the `claude-dev` container with `docker compose exec`.
+
+## Commands
+
+Use the repo-managed CLI:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh
+```
+
+Common operations:
+
+```bash
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "now + 2 hours" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh cron "0 3 * * *" -- "npm test"
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh at "03:00 tomorrow" --cwd /home/dev/projects/app -- ./scripts/nightly.sh
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh list
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh status <job-id>
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh logs <job-id>
+/home/dev/dev-env/scripts/runtime/aoc-schedule.sh cancel <job-id>
+```
+
+## Workflow
+
+1. Use the current working directory when it is under `/home/dev/projects`.
+2. If the current directory is not under `/home/dev/projects`, pass `--cwd /home/dev/projects/<repo>` or ask which repo should own the job.
+3. Submit one-off jobs with `at <time-spec> -- <command>`, or recurring jobs with `cron "<five-field-spec>" -- <command>`.
+4. Report the returned job id plus the exact `status` and `logs` commands.
+5. Use `list`, `status`, and `logs` instead of inspecting host `atq` directly.
+
+## Safety
+
+- Do not mount the Docker socket or SSH back to the host to schedule jobs.
+- Do not run host `at`, `atrm`, `crontab`, `systemctl`, or Docker directly from a container coding session for this workflow.
+- Confirm before scheduling destructive, externally visible, cloud-costing, or production-impacting commands.
+- If the CLI says the bridge inbox is missing, tell the user to run `/update` in the manager session and restart the container so the schedule mounts are available.

--- a/scripts/runtime/codex-home/skills/schedule-host-job/agents/openai.yaml
+++ b/scripts/runtime/codex-home/skills/schedule-host-job/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Schedule Host Job"
+  short_description: "Schedule container commands on the host"
+  default_prompt: "Use $schedule-host-job to schedule a command from this container session to run later through the host scheduling bridge."
+
+policy:
+  allow_implicit_invocation: true

--- a/scripts/runtime/install-schedule-bridge.sh
+++ b/scripts/runtime/install-schedule-bridge.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# install-schedule-bridge.sh — Install host bridge for container scheduling.
+
+set -euo pipefail
+
+info()  { echo ""; echo "=== $* ==="; }
+ok()    { echo "  OK: $*"; }
+skip()  { echo "  SKIP: $* (already done)"; }
+die()   { echo "ERROR: $*" >&2; exit 1; }
+
+if [[ $EUID -eq 0 ]]; then
+    sudo() { "$@"; }
+fi
+
+TARGET_USER="${AOC_USER:-dev}"
+id "$TARGET_USER" >/dev/null 2>&1 || die "User not found: $TARGET_USER"
+
+if command -v getent >/dev/null 2>&1; then
+    TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+else
+    TARGET_HOME="$(eval "printf '%s' ~$TARGET_USER")"
+fi
+TARGET_GROUP="$(id -gn "$TARGET_USER")"
+DEV_ENV="${DEV_ENV:-$TARGET_HOME/dev-env}"
+SCHEDULE_DIR="${AOC_SCHEDULE_DIR:-$TARGET_HOME/.always-on-claude/schedule}"
+SERVICE_NAME="always-on-claude-schedule-bridge"
+
+command -v systemctl >/dev/null 2>&1 || die "systemctl is required"
+[[ -x "$DEV_ENV/scripts/runtime/process-schedule-requests.sh" ]] || \
+    die "Missing executable processor: $DEV_ENV/scripts/runtime/process-schedule-requests.sh"
+
+info "Schedule bridge"
+
+for dir in inbox processing jobs logs status; do
+    mkdir -p "$SCHEDULE_DIR/$dir"
+done
+chown -R "$TARGET_USER:$TARGET_GROUP" "$SCHEDULE_DIR"
+chmod 700 "$SCHEDULE_DIR" "$SCHEDULE_DIR/inbox" "$SCHEDULE_DIR/processing" "$SCHEDULE_DIR/jobs"
+chmod 755 "$SCHEDULE_DIR/logs" "$SCHEDULE_DIR/status"
+ok "Schedule directories ready"
+
+missing_packages=()
+command -v at >/dev/null 2>&1 || missing_packages+=("at")
+command -v crontab >/dev/null 2>&1 || missing_packages+=("cron")
+
+if [[ ${#missing_packages[@]} -gt 0 ]]; then
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq "${missing_packages[@]}"
+        ok "Installed ${missing_packages[*]}"
+    else
+        die "${missing_packages[*]} required but apt-get is unavailable"
+    fi
+else
+    skip "at and cron"
+fi
+
+sudo systemctl enable --now atd.service >/dev/null 2>&1
+ok "atd enabled"
+
+if systemctl list-unit-files cron.service >/dev/null 2>&1; then
+    sudo systemctl enable --now cron.service >/dev/null 2>&1
+    ok "cron enabled"
+else
+    skip "cron.service not found"
+fi
+
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+PATH_FILE="/etc/systemd/system/${SERVICE_NAME}.path"
+
+cat <<EOF | sudo tee "$SERVICE_FILE" >/dev/null
+[Unit]
+Description=Process always-on-claude container schedule requests
+After=docker.service atd.service
+Requires=docker.service atd.service
+
+[Service]
+Type=oneshot
+User=$TARGET_USER
+Group=$TARGET_GROUP
+Environment=HOME=$TARGET_HOME
+Environment=DEV_ENV=$DEV_ENV
+Environment=AOC_SCHEDULE_DIR=$SCHEDULE_DIR
+WorkingDirectory=$DEV_ENV
+ExecStart=$DEV_ENV/scripts/runtime/process-schedule-requests.sh
+EOF
+
+cat <<EOF | sudo tee "$PATH_FILE" >/dev/null
+[Unit]
+Description=Watch always-on-claude container schedule request inbox
+
+[Path]
+PathExistsGlob=$SCHEDULE_DIR/inbox/*.json
+Unit=${SERVICE_NAME}.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${SERVICE_NAME}.path" >/dev/null 2>&1
+sudo systemctl restart "${SERVICE_NAME}.path" >/dev/null 2>&1
+ok "Schedule bridge enabled"

--- a/scripts/runtime/process-schedule-requests.sh
+++ b/scripts/runtime/process-schedule-requests.sh
@@ -1,0 +1,515 @@
+#!/bin/bash
+# process-schedule-requests.sh — Host-side processor for container schedule requests.
+
+set -euo pipefail
+
+info()  { echo ""; echo "=== $* ==="; }
+ok()    { echo "  OK: $*"; }
+warn()  { echo "  WARN: $*" >&2; }
+
+TARGET_USER="${AOC_USER:-dev}"
+if command -v getent >/dev/null 2>&1; then
+    TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+else
+    TARGET_HOME="$(eval "printf '%s' ~$TARGET_USER")"
+fi
+TARGET_GROUP="$(id -gn "$TARGET_USER")"
+DEV_ENV="${DEV_ENV:-$TARGET_HOME/dev-env}"
+SCHEDULE_DIR="${AOC_SCHEDULE_DIR:-$TARGET_HOME/.always-on-claude/schedule}"
+
+INBOX_DIR="$SCHEDULE_DIR/inbox"
+PROCESSING_DIR="$SCHEDULE_DIR/processing"
+JOBS_DIR="$SCHEDULE_DIR/jobs"
+LOG_DIR="$SCHEDULE_DIR/logs"
+STATUS_DIR="$SCHEDULE_DIR/status"
+LOCK_FILE="$SCHEDULE_DIR/.processor.lock"
+
+now_utc() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+valid_id() {
+    [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]]
+}
+
+container_cwd_ok() {
+    [[ "$1" == "/home/dev/projects" || "$1" == /home/dev/projects/* ]]
+}
+
+cron_field_ok() {
+    [[ "$1" =~ ^[A-Za-z0-9,*/.-]+$ ]]
+}
+
+cron_spec_ok() {
+    local spec="$1"
+    local fields=()
+    read -r -a fields <<< "$spec"
+
+    [[ ${#fields[@]} -eq 5 ]] || return 1
+
+    local field
+    for field in "${fields[@]}"; do
+        cron_field_ok "$field" || return 1
+    done
+}
+
+has_newline() {
+    [[ "$1" == *$'\n'* || "$1" == *$'\r'* ]]
+}
+
+write_invalid_status() {
+    local id="$1"
+    local reason="$2"
+    local tmp
+
+    valid_id "$id" || id="invalid-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+    tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+    jq -n \
+        --arg id "$id" \
+        --arg status "rejected" \
+        --arg reason "$reason" \
+        --arg updated_at "$(now_utc)" \
+        '{id: $id, status: $status, reason: $reason, updated_at: $updated_at}' > "$tmp"
+    mv "$tmp" "$STATUS_DIR/$id.json"
+}
+
+write_status_from_request() {
+    local request="$1"
+    local status="$2"
+    local reason="${3:-}"
+    local tmp id
+
+    id=$(jq -r '.id // empty' "$request" 2>/dev/null || true)
+    valid_id "$id" || id="$(basename "$request" .json)"
+    valid_id "$id" || id="invalid-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+
+    tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+    jq \
+        --arg status "$status" \
+        --arg reason "$reason" \
+        --arg updated_at "$(now_utc)" \
+        '. + {status: $status, updated_at: $updated_at}
+         | if $reason == "" then del(.reason) else . + {reason: $reason} end' \
+        "$request" > "$tmp"
+    mv "$tmp" "$STATUS_DIR/$id.json"
+}
+
+update_status_file() {
+    local status_file="$1"
+    local status="$2"
+    local exit_code="${3:-}"
+    local tmp
+
+    tmp=$(mktemp "$STATUS_DIR/.status.tmp.XXXXXX")
+    if [[ -n "$exit_code" ]]; then
+        jq \
+            --arg status "$status" \
+            --arg updated_at "$(now_utc)" \
+            --argjson exit_code "$exit_code" \
+            '.status = $status | .updated_at = $updated_at | .exit_code = $exit_code' \
+            "$status_file" > "$tmp"
+    else
+        jq \
+            --arg status "$status" \
+            --arg updated_at "$(now_utc)" \
+            '.status = $status | .updated_at = $updated_at' \
+            "$status_file" > "$tmp"
+    fi
+    mv "$tmp" "$status_file"
+}
+
+reject_request() {
+    local request="$1"
+    local reason="$2"
+
+    if jq -e . "$request" >/dev/null 2>&1; then
+        write_status_from_request "$request" "rejected" "$reason"
+    else
+        write_invalid_status "$(basename "$request" .json)" "$reason"
+    fi
+    warn "Rejected $(basename "$request"): $reason"
+}
+
+create_job_script() {
+    local id="$1"
+    local cwd="$2"
+    local command="$3"
+    local status_file="$4"
+    local log_file="$5"
+    local job_script="$6"
+    local recurring="${7:-false}"
+
+    {
+        printf '#!/bin/bash\n'
+        printf 'set -uo pipefail\n'
+        printf 'export HOME=%q\n' "$TARGET_HOME"
+        printf 'DEV_ENV=%q\n' "$DEV_ENV"
+        printf 'JOB_ID=%q\n' "$id"
+        printf 'CWD=%q\n' "$cwd"
+        printf 'COMMAND=%q\n' "$command"
+        printf 'STATUS_FILE=%q\n' "$status_file"
+        printf 'LOG_FILE=%q\n' "$log_file"
+        printf 'RECURRING=%q\n' "$recurring"
+        cat <<'JOB'
+
+now_utc() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+update_status() {
+    local status="$1"
+    local exit_code="${2:-}"
+    local tmp
+    local now
+
+    now="$(now_utc)"
+
+    tmp=$(mktemp "$(dirname "$STATUS_FILE")/.${JOB_ID}.tmp.XXXXXX")
+    if [[ "$RECURRING" == "true" && "$status" == "running" ]]; then
+        jq \
+            --arg status "$status" \
+            --arg updated_at "$now" \
+            --arg last_started_at "$now" \
+            '.status = $status | .updated_at = $updated_at | .last_started_at = $last_started_at' \
+            "$STATUS_FILE" > "$tmp"
+    elif [[ "$RECURRING" == "true" && -n "$exit_code" ]]; then
+        jq \
+            --arg status "scheduled" \
+            --arg last_run_status "$status" \
+            --arg updated_at "$now" \
+            --arg last_finished_at "$now" \
+            --argjson last_exit_code "$exit_code" \
+            '.status = $status
+             | .updated_at = $updated_at
+             | .last_run_status = $last_run_status
+             | .last_finished_at = $last_finished_at
+             | .last_exit_code = $last_exit_code' \
+            "$STATUS_FILE" > "$tmp"
+    elif [[ -n "$exit_code" ]]; then
+        jq \
+            --arg status "$status" \
+            --arg updated_at "$now" \
+            --argjson exit_code "$exit_code" \
+            '.status = $status | .updated_at = $updated_at | .exit_code = $exit_code' \
+            "$STATUS_FILE" > "$tmp"
+    else
+        jq \
+            --arg status "$status" \
+            --arg updated_at "$now" \
+            '.status = $status | .updated_at = $updated_at' \
+            "$STATUS_FILE" > "$tmp"
+    fi
+    mv "$tmp" "$STATUS_FILE"
+}
+
+{
+    echo "=== $(now_utc) job $JOB_ID starting ==="
+    echo "cwd: $CWD"
+    echo "command: $COMMAND"
+
+    update_status running
+
+    cd "$DEV_ENV" || exit 127
+
+    set +e
+    sudo --preserve-env=HOME docker compose exec -T -w "$CWD" dev bash -lc "$COMMAND"
+    rc=$?
+    set -e
+
+    if [[ "$rc" -eq 0 ]]; then
+        echo "=== $(now_utc) job $JOB_ID succeeded ==="
+        update_status succeeded "$rc"
+    else
+        echo "=== $(now_utc) job $JOB_ID failed: exit $rc ==="
+        update_status failed "$rc"
+    fi
+
+    exit "$rc"
+} >> "$LOG_FILE" 2>&1
+JOB
+    } > "$job_script"
+
+    chmod 700 "$job_script"
+}
+
+process_at_request() {
+    local request="$1"
+    local id time_spec cwd command label
+
+    id=$(jq -r '.id // empty' "$request")
+    time_spec=$(jq -r '.time // empty' "$request")
+    cwd=$(jq -r '.cwd // empty' "$request")
+    command=$(jq -r '.command // empty' "$request")
+    label=$(jq -r '.label // empty' "$request")
+
+    valid_id "$id" || { reject_request "$request" "Invalid id"; return 0; }
+    [[ -n "$time_spec" ]] || { reject_request "$request" "Missing time"; return 0; }
+    [[ -n "$cwd" ]] || { reject_request "$request" "Missing cwd"; return 0; }
+    [[ -n "$command" ]] || { reject_request "$request" "Missing command"; return 0; }
+    has_newline "$time_spec" && { reject_request "$request" "Time spec must be one line"; return 0; }
+    container_cwd_ok "$cwd" || { reject_request "$request" "cwd must be under /home/dev/projects"; return 0; }
+
+    if [[ ! -d "$cwd" ]]; then
+        reject_request "$request" "cwd does not exist on host: $cwd"
+        return 0
+    fi
+
+    if [[ -f "$STATUS_DIR/$id.json" ]]; then
+        reject_request "$request" "Duplicate job id"
+        return 0
+    fi
+
+    local status_file="$STATUS_DIR/$id.json"
+    local log_file="$LOG_DIR/$id.log"
+    local job_script="$JOBS_DIR/$id.sh"
+    local at_output at_job_id tmp
+
+    tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+    jq \
+        --arg status "accepted" \
+        --arg updated_at "$(now_utc)" \
+        '. + {status: $status, updated_at: $updated_at}' \
+        "$request" > "$tmp"
+    mv "$tmp" "$status_file"
+
+    create_job_script "$id" "$cwd" "$command" "$status_file" "$log_file" "$job_script" false
+
+    if ! at_output=$(printf '/bin/bash %q\n' "$job_script" | at -M "$time_spec" 2>&1); then
+        update_status_file "$status_file" "rejected"
+        tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+        jq --arg reason "$at_output" '.reason = $reason' "$status_file" > "$tmp"
+        mv "$tmp" "$status_file"
+        warn "at rejected $id: $at_output"
+        return 0
+    fi
+
+    at_job_id=$(printf '%s\n' "$at_output" | sed -n 's/^job \([0-9][0-9]*\).*/\1/p' | head -1)
+    tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+    jq \
+        --arg status "scheduled" \
+        --arg updated_at "$(now_utc)" \
+        --arg host_at_job_id "$at_job_id" \
+        --arg log_file "$log_file" \
+        --arg job_label "$label" \
+        '.status = $status
+         | .updated_at = $updated_at
+         | .host_at_job_id = $host_at_job_id
+         | .log_file = $log_file
+         | .label = $job_label' \
+        "$status_file" > "$tmp"
+    mv "$tmp" "$status_file"
+
+    ok "Scheduled $id${at_job_id:+ as at job $at_job_id}"
+}
+
+remove_crontab_entry() {
+    local id="$1"
+    local existing new
+
+    existing=$(mktemp)
+    new=$(mktemp)
+
+    crontab -l > "$existing" 2>/dev/null || true
+    awk -v id="$id" '
+        $0 == "# always-on-claude schedule bridge BEGIN " id {
+            skip = 1
+            next
+        }
+        $0 == "# always-on-claude schedule bridge END " id {
+            skip = 0
+            next
+        }
+        !skip { print }
+    ' "$existing" > "$new"
+
+    crontab "$new"
+    rm -f "$existing" "$new"
+}
+
+install_crontab_entry() {
+    local id="$1"
+    local schedule="$2"
+    local job_script="$3"
+    local existing new
+
+    remove_crontab_entry "$id"
+
+    existing=$(mktemp)
+    new=$(mktemp)
+
+    crontab -l > "$existing" 2>/dev/null || true
+    cp "$existing" "$new"
+    {
+        echo "# always-on-claude schedule bridge BEGIN $id"
+        printf '%s /bin/bash %q\n' "$schedule" "$job_script"
+        echo "# always-on-claude schedule bridge END $id"
+    } >> "$new"
+
+    crontab "$new"
+    rm -f "$existing" "$new"
+}
+
+process_cron_request() {
+    local request="$1"
+    local id schedule cwd command label
+
+    id=$(jq -r '.id // empty' "$request")
+    schedule=$(jq -r '.schedule // empty' "$request")
+    cwd=$(jq -r '.cwd // empty' "$request")
+    command=$(jq -r '.command // empty' "$request")
+    label=$(jq -r '.label // empty' "$request")
+
+    valid_id "$id" || { reject_request "$request" "Invalid id"; return 0; }
+    [[ -n "$schedule" ]] || { reject_request "$request" "Missing schedule"; return 0; }
+    [[ -n "$cwd" ]] || { reject_request "$request" "Missing cwd"; return 0; }
+    [[ -n "$command" ]] || { reject_request "$request" "Missing command"; return 0; }
+    has_newline "$schedule" && { reject_request "$request" "Cron schedule must be one line"; return 0; }
+    cron_spec_ok "$schedule" || { reject_request "$request" "Cron schedule must be exactly five valid fields"; return 0; }
+    container_cwd_ok "$cwd" || { reject_request "$request" "cwd must be under /home/dev/projects"; return 0; }
+    command -v crontab >/dev/null 2>&1 || { reject_request "$request" "crontab is not installed on the host"; return 0; }
+
+    if [[ ! -d "$cwd" ]]; then
+        reject_request "$request" "cwd does not exist on host: $cwd"
+        return 0
+    fi
+
+    if [[ -f "$STATUS_DIR/$id.json" ]]; then
+        reject_request "$request" "Duplicate job id"
+        return 0
+    fi
+
+    local status_file="$STATUS_DIR/$id.json"
+    local log_file="$LOG_DIR/$id.log"
+    local job_script="$JOBS_DIR/$id.sh"
+    local tmp
+
+    tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+    jq \
+        --arg status "accepted" \
+        --arg updated_at "$(now_utc)" \
+        '. + {status: $status, updated_at: $updated_at}' \
+        "$request" > "$tmp"
+    mv "$tmp" "$status_file"
+
+    create_job_script "$id" "$cwd" "$command" "$status_file" "$log_file" "$job_script" true
+    install_crontab_entry "$id" "$schedule" "$job_script"
+
+    tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+    jq \
+        --arg status "scheduled" \
+        --arg updated_at "$(now_utc)" \
+        --arg log_file "$log_file" \
+        --arg job_label "$label" \
+        '.status = $status
+         | .updated_at = $updated_at
+         | .log_file = $log_file
+         | .label = $job_label' \
+        "$status_file" > "$tmp"
+    mv "$tmp" "$status_file"
+
+    ok "Scheduled recurring job $id"
+}
+
+process_cancel_request() {
+    local request="$1"
+    local id target_id status_file current_status action at_job_id tmp
+
+    id=$(jq -r '.id // empty' "$request")
+    target_id=$(jq -r '.target_id // empty' "$request")
+
+    valid_id "$id" || { reject_request "$request" "Invalid id"; return 0; }
+    valid_id "$target_id" || { reject_request "$request" "Invalid target_id"; return 0; }
+
+    status_file="$STATUS_DIR/$target_id.json"
+    [[ -f "$status_file" ]] || { reject_request "$request" "Target job not found"; return 0; }
+
+    current_status=$(jq -r '.status // empty' "$status_file")
+    action=$(jq -r '.action // empty' "$status_file")
+    if [[ "$action" == "cron" ]]; then
+        if [[ "$current_status" != "scheduled" && "$current_status" != "accepted" && "$current_status" != "running" ]]; then
+            reject_request "$request" "Target job is not cancelable: $current_status"
+            return 0
+        fi
+    elif [[ "$current_status" != "scheduled" && "$current_status" != "accepted" ]]; then
+        reject_request "$request" "Target job is not cancelable: $current_status"
+        return 0
+    fi
+
+    if [[ "$action" == "cron" ]]; then
+        remove_crontab_entry "$target_id"
+    else
+        at_job_id=$(jq -r '.host_at_job_id // empty' "$status_file")
+        if [[ -n "$at_job_id" ]]; then
+            if ! atrm "$at_job_id" 2>/dev/null; then
+                reject_request "$request" "atrm failed for host at job $at_job_id"
+                return 0
+            fi
+        fi
+    fi
+
+    tmp=$(mktemp "$STATUS_DIR/.${target_id}.tmp.XXXXXX")
+    jq \
+        --arg status "canceled" \
+        --arg updated_at "$(now_utc)" \
+        --arg canceled_by_request "$id" \
+        '.status = $status | .updated_at = $updated_at | .canceled_by_request = $canceled_by_request' \
+        "$status_file" > "$tmp"
+    mv "$tmp" "$status_file"
+
+    write_status_from_request "$request" "succeeded"
+    ok "Canceled $target_id"
+}
+
+process_request() {
+    local request="$1"
+    local version action
+
+    if ! jq -e . "$request" >/dev/null 2>&1; then
+        reject_request "$request" "Invalid JSON"
+        return 0
+    fi
+
+    version=$(jq -r '.version // empty' "$request")
+    action=$(jq -r '.action // empty' "$request")
+
+    [[ "$version" == "1" ]] || { reject_request "$request" "Unsupported request version"; return 0; }
+
+    case "$action" in
+        at)
+            process_at_request "$request"
+            ;;
+        cron)
+            process_cron_request "$request"
+            ;;
+        cancel)
+            process_cancel_request "$request"
+            ;;
+        *)
+            reject_request "$request" "Unsupported action: $action"
+            ;;
+    esac
+}
+
+main() {
+    mkdir -p "$INBOX_DIR" "$PROCESSING_DIR" "$JOBS_DIR" "$LOG_DIR" "$STATUS_DIR"
+    if [[ $EUID -eq 0 ]]; then
+        chown -R "$TARGET_USER:$TARGET_GROUP" "$SCHEDULE_DIR"
+    fi
+
+    exec 9>"$LOCK_FILE"
+    if ! flock -n 9; then
+        warn "Another schedule processor is already running"
+        exit 0
+    fi
+
+    shopt -s nullglob
+    local request work
+    for request in "$INBOX_DIR"/*.json; do
+        work="$PROCESSING_DIR/$(basename "$request")"
+        mv "$request" "$work" || continue
+        process_request "$work" || true
+        rm -f "$work"
+    done
+}
+
+main "$@"

--- a/scripts/runtime/self-update.sh
+++ b/scripts/runtime/self-update.sh
@@ -380,6 +380,19 @@ elif [[ -x "$DEV_ENV/scripts/runtime/sync-codex-config.sh" ]]; then
     fi
 fi
 
+if [[ -x "$DEV_ENV/scripts/runtime/sync-claude-personalization.sh" ]]; then
+    claude_setup_status=$("$DEV_ENV/scripts/runtime/sync-claude-personalization.sh")
+    if [[ "$claude_setup_status" == "updated" ]]; then
+        ok "Updated Claude home state"
+        host_updated=true
+    fi
+fi
+
+if [[ -x "$DEV_ENV/scripts/runtime/install-schedule-bridge.sh" && -f "$DEV_ENV/.provisioned" ]]; then
+    "$DEV_ENV/scripts/runtime/install-schedule-bridge.sh"
+    host_updated=true
+fi
+
 if [[ "$host_updated" == "true" ]]; then
     UPDATED+=("host-scripts: updated")
 fi

--- a/scripts/runtime/sync-claude-personalization.sh
+++ b/scripts/runtime/sync-claude-personalization.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# sync-claude-personalization.sh — Materialize repo-managed Claude user state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_HOME="$SCRIPT_DIR/claude-home"
+CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
+
+CHANGED=0
+
+sync_file() {
+    local src="$1"
+    local dest="$2"
+    local mode="$3"
+
+    mkdir -p "$(dirname "$dest")"
+
+    if [[ ! -f "$dest" ]] || ! cmp -s "$src" "$dest"; then
+        cp "$src" "$dest"
+        CHANGED=1
+    fi
+
+    chmod "$mode" "$dest"
+}
+
+if [[ -d "$SOURCE_HOME/commands" ]]; then
+    while IFS= read -r -d '' src; do
+        rel="${src#"$SOURCE_HOME/"}"
+        sync_file "$src" "$CLAUDE_HOME/$rel" 644
+    done < <(find "$SOURCE_HOME/commands" -type f -print0)
+fi
+
+if [[ -d "$SOURCE_HOME/skills" ]]; then
+    while IFS= read -r -d '' src; do
+        rel="${src#"$SOURCE_HOME/"}"
+        sync_file "$src" "$CLAUDE_HOME/$rel" 644
+    done < <(find "$SOURCE_HOME/skills" -type f -print0)
+fi
+
+if [[ "$CHANGED" -eq 1 ]]; then
+    echo "updated"
+else
+    echo "unchanged"
+fi

--- a/scripts/runtime/sync-codex-personalization.sh
+++ b/scripts/runtime/sync-codex-personalization.sh
@@ -123,6 +123,7 @@ sync_dir "$SOURCE_HOME/skills/futuapi" "$CODEX_HOME/skills/futuapi"
 sync_dir "$SOURCE_HOME/skills/install-futu-opend" "$CODEX_HOME/skills/install-futu-opend"
 sync_dir "$SOURCE_HOME/skills/deploy-proxy" "$CODEX_HOME/skills/deploy-proxy"
 sync_dir "$SOURCE_HOME/skills/release-plugin" "$CODEX_HOME/skills/release-plugin"
+sync_dir "$SOURCE_HOME/skills/schedule-host-job" "$CODEX_HOME/skills/schedule-host-job"
 
 sync_managed_mcp_config
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,10 +14,15 @@ cd "$REPO_ROOT"
 
 total_pass=0
 total_fail=0
-files=("${@}")
+files=()
+if [[ $# -gt 0 ]]; then
+    files=("$@")
+fi
 
 if [[ ${#files[@]} -eq 0 ]]; then
-    mapfile -t files < <(find tests -name 'test-*.sh' -type f | sort)
+    while IFS= read -r file; do
+        files+=("$file")
+    done < <(find tests -name 'test-*.sh' -type f | sort)
 fi
 
 for file in "${files[@]}"; do

--- a/tests/test-aoc-schedule.sh
+++ b/tests/test-aoc-schedule.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Tests for scripts/runtime/aoc-schedule.sh
+
+SCHEDULE_SCRIPT="$REPO_ROOT/scripts/runtime/aoc-schedule.sh"
+
+setup() {
+    mkdir -p "$TEST_DIR/schedule/inbox" "$TEST_DIR/schedule/status" "$TEST_DIR/schedule/logs"
+}
+
+test_at_writes_request_json() {
+    local output request id command cwd
+
+    output=$(AOC_SCHEDULE_DIR="$TEST_DIR/schedule" bash "$SCHEDULE_SCRIPT" \
+        at "now + 1 hour" --cwd /home/dev/projects/app -- "echo hello")
+
+    assert_contains "$output" "Submitted:"
+
+    request=$(find "$TEST_DIR/schedule/inbox" -name '*.json' -type f | head -1)
+    assert_file_exists "$request"
+
+    id=$(jq -r '.id' "$request")
+    command=$(jq -r '.command' "$request")
+    cwd=$(jq -r '.cwd' "$request")
+
+    [[ "$id" =~ ^[0-9]{8}T[0-9]{6}Z-[a-f0-9]+$ ]] || _fail "unexpected id: $id"
+    assert_eq "echo hello" "$command"
+    assert_eq "/home/dev/projects/app" "$cwd"
+    assert_eq "at" "$(jq -r '.action' "$request")"
+}
+
+test_at_rejects_cwd_outside_projects() {
+    assert_exit_code 1 env AOC_SCHEDULE_DIR="$TEST_DIR/schedule" bash "$SCHEDULE_SCRIPT" \
+        at "now + 1 hour" --cwd /tmp -- "echo no"
+}
+
+test_cron_writes_request_json() {
+    local request
+
+    AOC_SCHEDULE_DIR="$TEST_DIR/schedule" bash "$SCHEDULE_SCRIPT" \
+        cron "0 3 * * *" --cwd /home/dev/projects/app -- "npm test" >/dev/null
+
+    request=$(find "$TEST_DIR/schedule/inbox" -name '*.json' -type f | head -1)
+    assert_file_exists "$request"
+    assert_eq "cron" "$(jq -r '.action' "$request")"
+    assert_eq "0 3 * * *" "$(jq -r '.schedule' "$request")"
+    assert_eq "npm test" "$(jq -r '.command' "$request")"
+}
+
+test_cron_rejects_invalid_spec() {
+    assert_exit_code 1 env AOC_SCHEDULE_DIR="$TEST_DIR/schedule" bash "$SCHEDULE_SCRIPT" \
+        cron "0 3 * *" --cwd /home/dev/projects/app -- "npm test"
+}
+
+test_list_reads_status_files() {
+    cat > "$TEST_DIR/schedule/status/job1.json" <<'EOF'
+{"id":"job1","status":"scheduled","time":"03:00 tomorrow","command":"npm test","updated_at":"2026-04-24T04:00:00Z"}
+EOF
+
+    local output
+    output=$(AOC_SCHEDULE_DIR="$TEST_DIR/schedule" bash "$SCHEDULE_SCRIPT" list)
+
+    assert_contains "$output" "job1"
+    assert_contains "$output" "scheduled"
+    assert_contains "$output" "npm test"
+}
+
+test_cancel_writes_cancel_request() {
+    local request
+
+    AOC_SCHEDULE_DIR="$TEST_DIR/schedule" bash "$SCHEDULE_SCRIPT" cancel job1 >/dev/null
+
+    request=$(find "$TEST_DIR/schedule/inbox" -name '*.json' -type f | head -1)
+    assert_file_exists "$request"
+    assert_eq "cancel" "$(jq -r '.action' "$request")"
+    assert_eq "job1" "$(jq -r '.target_id' "$request")"
+}

--- a/tests/test-sync-claude-personalization.sh
+++ b/tests/test-sync-claude-personalization.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Tests for scripts/runtime/sync-claude-personalization.sh
+
+SYNC_SCRIPT="$REPO_ROOT/scripts/runtime/sync-claude-personalization.sh"
+
+test_syncs_user_scope_schedule_command() {
+    local first_output second_output
+
+    first_output=$(CLAUDE_HOME="$HOME/.claude" bash "$SYNC_SCRIPT")
+    second_output=$(CLAUDE_HOME="$HOME/.claude" bash "$SYNC_SCRIPT")
+
+    assert_eq "updated" "$first_output"
+    assert_eq "unchanged" "$second_output"
+    assert_file_exists "$HOME/.claude/commands/schedule.md"
+    assert_file_exists "$HOME/.claude/commands/host-schedule.md"
+    assert_file_exists "$HOME/.claude/skills/host-schedule/SKILL.md"
+    assert_contains "$(cat "$HOME/.claude/commands/schedule.md")" "aoc-schedule.sh"
+    assert_contains "$(cat "$HOME/.claude/commands/host-schedule.md")" "aoc-schedule.sh"
+    assert_contains "$(cat "$HOME/.claude/skills/host-schedule/SKILL.md")" "aoc-schedule.sh"
+}


### PR DESCRIPTION
## Summary

- Add a narrow host scheduling bridge so container coding sessions can submit jobs without direct host `at`, cron, Docker socket, or SSH access.
- Add `aoc-schedule.sh`, host request processor, systemd path/service installer, and compose mounts where only the inbox is writable from the container.
- Support both one-off `at` jobs and recurring five-field `cron` schedules. Recurring jobs are stored as managed blocks in the host `dev` user's crontab and can be removed with `aoc-schedule cancel <job-id>`.
- Add Claude `/host-schedule` user-scope command/skill and Codex `schedule-host-job` user-scope skill, wired into install/update personalization sync.
- Document the schedule bridge and add focused tests for the CLI and Claude command sync.

## Validation

- `bash tests/run.sh`
- `docker compose config`
- `python3 /Users/verkyyi/.codex/skills/.system/skill-creator/scripts/quick_validate.py scripts/runtime/codex-home/skills/schedule-host-job`
- `git diff --check`
- Applied to `cc-1`; verified one-off and recurring cron smoke jobs execute inside the container and write status/logs

## Notes

This is stacked on #118 and targets `feat/codex-runtime-support` to keep the bridge update separate from the larger runtime-support PR.
