### PR TITLE
Add gmail-full inbox command

### DIFF
--- a/.claude/commands/inbox.md
+++ b/.claude/commands/inbox.md
@@ -1,0 +1,7 @@
+# Inbox (daily triage)
+
+Check my Gmail inbox from the last 24 hours. Group emails into `urgent`, `needs reply`, `waiting`, and `FYI`.
+
+Do not automatically ignore promotions or social emails. Include them when they are relevant to my work, money, accounts, purchases, subscriptions, travel, security, job search, or anything I am actively dealing with. If uncertain, include them in `FYI` instead of omitting them.
+
+Do not archive, filter, or mark anything read unless I approve.

--- a/docs/gmail-full.md
+++ b/docs/gmail-full.md
@@ -1,0 +1,66 @@
+# gmail-full MCP
+
+Optional helper for users who want a custom Gmail MCP alongside the official Gmail connector.
+
+## What it does
+
+`scripts/deploy/setup-gmail-full.sh`:
+
+1. Copies `credentials.json` and `gcp-oauth.keys.json` into a private target dir
+2. Configures `gmail-full` for Codex in `~/.codex/config.toml`
+3. Configures `gmail-full` for Claude Code in the user-scoped MCP registry
+
+The helper never writes OAuth files into the repo.
+
+## Basic usage
+
+If your source OAuth files already live in `~/.gmail-mcp`:
+
+```bash
+GMAIL_FULL_SOURCE_DIR="$HOME/.gmail-mcp" \
+bash scripts/deploy/setup-gmail-full.sh
+```
+
+Or provide explicit file paths:
+
+```bash
+GMAIL_FULL_CREDENTIALS_FILE=/path/to/credentials.json \
+GMAIL_FULL_OAUTH_FILE=/path/to/gcp-oauth.keys.json \
+bash scripts/deploy/setup-gmail-full.sh
+```
+
+## Default target paths
+
+- Provisioned hosts: `~/.codex/gmail-mcp`
+- Non-provisioned/local machines: `~/.gmail-mcp`
+
+The provisioned-host default is intentional. `~/.codex` is shared between the host and the container, so placing the OAuth files under `~/.codex/gmail-mcp` makes the same `gmail-full` setup work in both places.
+
+Override the target if needed:
+
+```bash
+GMAIL_FULL_TARGET_DIR=/path/to/private-dir \
+GMAIL_FULL_SOURCE_DIR="$HOME/.gmail-mcp" \
+bash scripts/deploy/setup-gmail-full.sh
+```
+
+## Provisioned host notes
+
+If you want to verify host-level Claude directly without entering the workspace picker, use the built-in bypass:
+
+```bash
+NO_CLAUDE=1 bash -lic 'claude mcp get gmail-full'
+```
+
+Read-only verification example:
+
+```bash
+NO_CLAUDE=1 bash -lic 'claude -p --permission-mode bypassPermissions --output-format text "Use the MCP server named gmail-full to do exactly one read-only email lookup. Search for the single most recent message in my inbox. Do not modify the mailbox. Return only three lines: STATUS: <ok or error>, FROM: <sender>, SUBJECT: <subject>."'
+```
+
+Container-side verification:
+
+```bash
+docker exec claude-dev bash -lc 'claude mcp get gmail-full'
+docker exec claude-dev bash -lc 'codex mcp get gmail-full'
+```

--- a/scripts/deploy/setup-gmail-full.sh
+++ b/scripts/deploy/setup-gmail-full.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# setup-gmail-full.sh — Optional helper to configure gmail-full for Codex and Claude.
+#
+# Usage:
+#   GMAIL_FULL_SOURCE_DIR="$HOME/.gmail-mcp" bash scripts/deploy/setup-gmail-full.sh
+#
+# Or provide individual files:
+#   GMAIL_FULL_CREDENTIALS_FILE=/path/to/credentials.json \
+#   GMAIL_FULL_OAUTH_FILE=/path/to/gcp-oauth.keys.json \
+#   bash scripts/deploy/setup-gmail-full.sh
+#
+# On provisioned hosts, the default target is ~/.codex/gmail-mcp so the same
+# files are visible to both the host and the container. Elsewhere, the default
+# target is ~/.gmail-mcp.
+
+set -euo pipefail
+
+info()  { echo ""; echo "=== $* ==="; }
+ok()    { echo "  OK: $*"; }
+skip()  { echo "  SKIP: $* (already done)"; }
+die()   { echo "ERROR: $*" >&2; exit 1; }
+
+DEV_ENV_ROOT="${DEV_ENV:-$HOME/dev-env}"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+CLAUDE_SCOPE="${CLAUDE_SCOPE:-user}"
+GMAIL_FULL_PACKAGE="${GMAIL_FULL_PACKAGE:-@gongrzhe/server-gmail-autoauth-mcp}"
+GMAIL_FULL_SOURCE_DIR="${GMAIL_FULL_SOURCE_DIR:-}"
+GMAIL_FULL_CREDENTIALS_FILE="${GMAIL_FULL_CREDENTIALS_FILE:-}"
+GMAIL_FULL_OAUTH_FILE="${GMAIL_FULL_OAUTH_FILE:-}"
+CHANGED=0
+
+default_target_dir() {
+    if [[ -f "$DEV_ENV_ROOT/.provisioned" ]]; then
+        echo "$CODEX_HOME/gmail-mcp"
+    else
+        echo "$HOME/.gmail-mcp"
+    fi
+}
+
+trim_trailing_blank_lines() {
+    local file="$1"
+
+    awk '
+        {
+            lines[NR] = $0
+        }
+        $0 ~ /[^[:space:]]/ {
+            last = NR
+        }
+        END {
+            for (i = 1; i <= last; i++) {
+                print lines[i]
+            }
+        }
+    ' "$file"
+}
+
+copy_if_changed() {
+    local src="$1"
+    local dest="$2"
+    local mode="$3"
+
+    mkdir -p "$(dirname "$dest")"
+
+    if [[ ! -f "$dest" ]] || ! cmp -s "$src" "$dest"; then
+        cp "$src" "$dest"
+        CHANGED=1
+    fi
+
+    chmod "$mode" "$dest"
+}
+
+resolve_source_files() {
+    if [[ -n "$GMAIL_FULL_SOURCE_DIR" ]]; then
+        if [[ -z "$GMAIL_FULL_CREDENTIALS_FILE" ]]; then
+            GMAIL_FULL_CREDENTIALS_FILE="$GMAIL_FULL_SOURCE_DIR/credentials.json"
+        fi
+        if [[ -z "$GMAIL_FULL_OAUTH_FILE" ]]; then
+            GMAIL_FULL_OAUTH_FILE="$GMAIL_FULL_SOURCE_DIR/gcp-oauth.keys.json"
+        fi
+    fi
+}
+
+ensure_credentials() {
+    local target_dir="$1"
+    local target_credentials="$2"
+    local target_oauth="$3"
+
+    resolve_source_files
+
+    mkdir -p "$target_dir"
+    chmod 700 "$target_dir"
+
+    if [[ -n "$GMAIL_FULL_CREDENTIALS_FILE" || -n "$GMAIL_FULL_OAUTH_FILE" ]]; then
+        [[ -n "$GMAIL_FULL_CREDENTIALS_FILE" ]] || die "Set both GMAIL_FULL_CREDENTIALS_FILE and GMAIL_FULL_OAUTH_FILE."
+        [[ -n "$GMAIL_FULL_OAUTH_FILE" ]] || die "Set both GMAIL_FULL_CREDENTIALS_FILE and GMAIL_FULL_OAUTH_FILE."
+        [[ -f "$GMAIL_FULL_CREDENTIALS_FILE" ]] || die "Credentials file not found: $GMAIL_FULL_CREDENTIALS_FILE"
+        [[ -f "$GMAIL_FULL_OAUTH_FILE" ]] || die "OAuth keys file not found: $GMAIL_FULL_OAUTH_FILE"
+
+        copy_if_changed "$GMAIL_FULL_CREDENTIALS_FILE" "$target_credentials" 600
+        copy_if_changed "$GMAIL_FULL_OAUTH_FILE" "$target_oauth" 600
+        ok "Credential files available at $target_dir"
+        return 0
+    fi
+
+    if [[ -f "$target_credentials" && -f "$target_oauth" ]]; then
+        skip "Credential files"
+        chmod 600 "$target_credentials" "$target_oauth"
+        return 0
+    fi
+
+    die "Provide GMAIL_FULL_SOURCE_DIR or both GMAIL_FULL_CREDENTIALS_FILE and GMAIL_FULL_OAUTH_FILE."
+}
+
+sync_codex_config() {
+    local target_credentials="$1"
+    local target_oauth="$2"
+    local config_dir="$CODEX_HOME"
+    local config_file="$config_dir/config.toml"
+    local stripped merged
+
+    mkdir -p "$config_dir"
+    stripped=$(mktemp)
+    merged=$(mktemp)
+
+    if [[ -f "$config_file" ]]; then
+        awk '
+            BEGIN { skip = 0 }
+            /^\[/ {
+                if ($0 ~ /^\[mcp_servers\.gmail-full(\.env|\.tools\.search_emails)?\]$/) {
+                    skip = 1
+                    next
+                }
+                if (skip) {
+                    skip = 0
+                }
+            }
+            !skip { print }
+        ' "$config_file" > "$stripped"
+        trim_trailing_blank_lines "$stripped" > "$merged"
+    else
+        : > "$merged"
+    fi
+
+    if [[ -s "$merged" ]]; then
+        printf '\n\n' >> "$merged"
+    fi
+
+    cat >> "$merged" <<EOF
+[mcp_servers.gmail-full]
+command = "npx"
+args = ["$GMAIL_FULL_PACKAGE"]
+
+[mcp_servers.gmail-full.env]
+GMAIL_CREDENTIALS_PATH = "$target_credentials"
+GMAIL_OAUTH_PATH = "$target_oauth"
+
+[mcp_servers.gmail-full.tools.search_emails]
+approval_mode = "approve"
+EOF
+
+    if [[ -f "$config_file" ]] && cmp -s "$merged" "$config_file"; then
+        skip "Codex gmail-full MCP"
+        rm -f "$merged" "$stripped"
+        return 0
+    fi
+
+    mv "$merged" "$config_file"
+    chmod 600 "$config_file"
+    rm -f "$stripped"
+    CHANGED=1
+    ok "Configured Codex gmail-full MCP"
+}
+
+claude_mcp_matches() {
+    local target_credentials="$1"
+    local target_oauth="$2"
+    local output
+
+    if ! command -v claude >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if ! output=$(claude mcp get gmail-full 2>/dev/null); then
+        return 1
+    fi
+
+    [[ "$output" == *"Scope:"* ]] || return 1
+    [[ "$output" == *"Command: npx"* ]] || return 1
+    [[ "$output" == *"Args: $GMAIL_FULL_PACKAGE"* ]] || return 1
+    [[ "$output" == *"GMAIL_CREDENTIALS_PATH=$target_credentials"* ]] || return 1
+    [[ "$output" == *"GMAIL_OAUTH_PATH=$target_oauth"* ]] || return 1
+}
+
+sync_claude_config() {
+    local target_credentials="$1"
+    local target_oauth="$2"
+    local json
+
+    if ! command -v claude >/dev/null 2>&1; then
+        skip "Claude Code gmail-full MCP (claude not installed)"
+        return 0
+    fi
+
+    if claude_mcp_matches "$target_credentials" "$target_oauth"; then
+        skip "Claude Code gmail-full MCP"
+        return 0
+    fi
+
+    if claude mcp get gmail-full >/dev/null 2>&1; then
+        claude mcp remove "gmail-full" -s "$CLAUDE_SCOPE" >/dev/null 2>&1 || true
+    fi
+
+    json=$(printf '{"type":"stdio","command":"npx","args":["%s"],"env":{"GMAIL_CREDENTIALS_PATH":"%s","GMAIL_OAUTH_PATH":"%s"}}' \
+        "$GMAIL_FULL_PACKAGE" "$target_credentials" "$target_oauth")
+
+    claude mcp add-json -s "$CLAUDE_SCOPE" gmail-full "$json" >/dev/null
+    CHANGED=1
+    ok "Configured Claude Code gmail-full MCP"
+}
+
+main() {
+    local target_dir target_credentials target_oauth
+    target_dir="${GMAIL_FULL_TARGET_DIR:-$(default_target_dir)}"
+    target_credentials="$target_dir/credentials.json"
+    target_oauth="$target_dir/gcp-oauth.keys.json"
+
+    info "gmail-full setup"
+    echo "  Target dir: $target_dir"
+
+    ensure_credentials "$target_dir" "$target_credentials" "$target_oauth"
+    sync_codex_config "$target_credentials" "$target_oauth"
+    sync_claude_config "$target_credentials" "$target_oauth"
+
+    echo ""
+    if [[ "$CHANGED" -eq 1 ]]; then
+        echo "STATUS: updated"
+    else
+        echo "STATUS: unchanged"
+    fi
+}
+
+main "$@"

--- a/tests/test-setup-gmail-full.sh
+++ b/tests/test-setup-gmail-full.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Tests for scripts/deploy/setup-gmail-full.sh
+
+SETUP_GMAIL_FULL_SCRIPT="$REPO_ROOT/scripts/deploy/setup-gmail-full.sh"
+
+create_source_credentials() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "$dir/credentials.json" <<'EOF'
+{"installed":{"client_id":"test-client"}}
+EOF
+    cat > "$dir/gcp-oauth.keys.json" <<'EOF'
+{"refresh_token":"test-refresh"}
+EOF
+}
+
+mock_claude_missing_server() {
+    cat > "$TEST_DIR/bin/claude" <<EOF
+#!/bin/bash
+echo "\$*" >> "$TEST_DIR/claude.log"
+
+if [[ "\$1 \$2 \$3" == "mcp get gmail-full" ]]; then
+    exit 1
+fi
+
+if [[ "\$1 \$2" == "mcp add-json" ]]; then
+    exit 0
+fi
+
+if [[ "\$1 \$2" == "mcp remove" ]]; then
+    exit 0
+fi
+
+exit 0
+EOF
+    chmod +x "$TEST_DIR/bin/claude"
+}
+
+mock_claude_matching_server() {
+    local credentials="$1"
+    local oauth="$2"
+
+    cat > "$TEST_DIR/bin/claude" <<EOF
+#!/bin/bash
+echo "\$*" >> "$TEST_DIR/claude.log"
+
+if [[ "\$1 \$2 \$3" == "mcp get gmail-full" ]]; then
+    cat <<'EOM'
+gmail-full:
+  Scope: User config (available in all your projects)
+  Status: ✓ Connected
+  Type: stdio
+  Command: npx
+  Args: @gongrzhe/server-gmail-autoauth-mcp
+  Environment:
+    GMAIL_CREDENTIALS_PATH=$credentials
+    GMAIL_OAUTH_PATH=$oauth
+EOM
+    exit 0
+fi
+
+if [[ "\$1 \$2" == "mcp add-json" ]]; then
+    exit 0
+fi
+
+if [[ "\$1 \$2" == "mcp remove" ]]; then
+    exit 0
+fi
+
+exit 0
+EOF
+    chmod +x "$TEST_DIR/bin/claude"
+}
+
+test_defaults_to_local_target_and_preserves_existing_codex_config() {
+    local source_dir output config
+    source_dir="$HOME/source"
+    create_source_credentials "$source_dir"
+
+    mkdir -p "$HOME/.codex"
+    cat > "$HOME/.codex/config.toml" <<'EOF'
+approvals_reviewer = "user"
+
+[plugins."github@openai-curated"]
+enabled = true
+EOF
+
+    output=$(GMAIL_FULL_SOURCE_DIR="$source_dir" bash "$SETUP_GMAIL_FULL_SCRIPT")
+    config=$(cat "$HOME/.codex/config.toml")
+
+    assert_contains "$output" "STATUS: updated"
+    assert_file_exists "$HOME/.gmail-mcp/credentials.json"
+    assert_file_exists "$HOME/.gmail-mcp/gcp-oauth.keys.json"
+    assert_contains "$config" 'approvals_reviewer = "user"'
+    assert_contains "$config" $'[plugins."github@openai-curated"]\nenabled = true'
+    assert_contains "$config" '[mcp_servers.gmail-full]'
+    assert_contains "$config" 'GMAIL_CREDENTIALS_PATH = "'"$HOME"'/.gmail-mcp/credentials.json"'
+    assert_contains "$config" 'GMAIL_OAUTH_PATH = "'"$HOME"'/.gmail-mcp/gcp-oauth.keys.json"'
+}
+
+test_uses_shared_codex_target_on_provisioned_hosts_and_registers_claude() {
+    local source_dir output config claude_log
+    source_dir="$HOME/source"
+    create_source_credentials "$source_dir"
+    mkdir -p "$HOME/dev-env"
+    touch "$HOME/dev-env/.provisioned"
+    mock_claude_missing_server
+
+    output=$(GMAIL_FULL_SOURCE_DIR="$source_dir" bash "$SETUP_GMAIL_FULL_SCRIPT")
+    config=$(cat "$HOME/.codex/config.toml")
+    claude_log=$(cat "$TEST_DIR/claude.log")
+
+    assert_contains "$output" "STATUS: updated"
+    assert_file_exists "$HOME/.codex/gmail-mcp/credentials.json"
+    assert_file_exists "$HOME/.codex/gmail-mcp/gcp-oauth.keys.json"
+    assert_contains "$config" 'GMAIL_CREDENTIALS_PATH = "'"$HOME"'/.codex/gmail-mcp/credentials.json"'
+    assert_contains "$config" 'GMAIL_OAUTH_PATH = "'"$HOME"'/.codex/gmail-mcp/gcp-oauth.keys.json"'
+    assert_contains "$claude_log" 'mcp add-json -s user gmail-full'
+}
+
+test_is_idempotent_when_target_files_and_claude_registration_already_match() {
+    local output config before after
+    mkdir -p "$HOME/.gmail-mcp" "$HOME/.codex"
+
+    cat > "$HOME/.gmail-mcp/credentials.json" <<'EOF'
+{"installed":{"client_id":"test-client"}}
+EOF
+    cat > "$HOME/.gmail-mcp/gcp-oauth.keys.json" <<'EOF'
+{"refresh_token":"test-refresh"}
+EOF
+    cat > "$HOME/.codex/config.toml" <<EOF
+[mcp_servers.gmail-full]
+command = "npx"
+args = ["@gongrzhe/server-gmail-autoauth-mcp"]
+
+[mcp_servers.gmail-full.env]
+GMAIL_CREDENTIALS_PATH = "$HOME/.gmail-mcp/credentials.json"
+GMAIL_OAUTH_PATH = "$HOME/.gmail-mcp/gcp-oauth.keys.json"
+
+[mcp_servers.gmail-full.tools.search_emails]
+approval_mode = "approve"
+EOF
+
+    mock_claude_matching_server "$HOME/.gmail-mcp/credentials.json" "$HOME/.gmail-mcp/gcp-oauth.keys.json"
+
+    before=$(cat "$HOME/.codex/config.toml")
+    output=$(bash "$SETUP_GMAIL_FULL_SCRIPT")
+    after=$(cat "$HOME/.codex/config.toml")
+
+    assert_contains "$output" "STATUS: unchanged"
+    assert_eq "$before" "$after"
+    assert_file_exists "$TEST_DIR/claude.log"
+    assert_contains "$(cat "$TEST_DIR/claude.log")" 'mcp get gmail-full'
+    if [[ "$(cat "$TEST_DIR/claude.log")" == *'mcp add-json -s user gmail-full'* ]]; then
+        _fail "expected claude mcp add-json to be skipped"
+    fi
+}


### PR DESCRIPTION
## Summary

- Add `/inbox` Claude slash command for Gmail inbox triage.
- Add optional gmail-full setup helper for installing shared Gmail MCP configuration on local or provisioned hosts.
- Document the gmail-full setup flow and cover it with shell tests.

## Validation

- `bash tests/run.sh tests/test-setup-gmail-full.sh`
