### PR TITLE
[codex] Add Mac mini local deployment support

### DIFF
--- a/docker-compose.macmini.yml
+++ b/docker-compose.macmini.yml
@@ -4,7 +4,7 @@
 # Mac mini through the host's existing Tailscale SSH, then use docker exec.
 #
 # Usage on the Mac mini:
-#   mkdir -p ~/aoc-data/{claude,codex,gitconfig,gh,aws,overnight,public} ~/projects
+#   mkdir -p ~/aoc-data/{claude,codex,gitconfig,gh,aws,overnight,public} ~/.always-on-claude/schedule/{inbox,status,logs} ~/projects
 #   docker compose -f docker-compose.macmini.yml up -d
 #   docker exec -it claude-dev bash -lc 'bash ~/dev-env/scripts/portable/start-claude-portable.sh'
 
@@ -33,6 +33,9 @@ services:
       - ${HOME}/projects:/home/dev/projects
       - ${HOME}/always-on-claude:/home/dev/dev-env:ro
       - ${HOME}/.ssh:/home/dev/.ssh:ro
+      - ${HOME}/.always-on-claude/schedule/inbox:/home/dev/.aoc/schedule/inbox
+      - ${HOME}/.always-on-claude/schedule/status:/home/dev/.aoc/schedule/status:ro
+      - ${HOME}/.always-on-claude/schedule/logs:/home/dev/.aoc/schedule/logs:ro
 
     environment:
       - NODE_ENV=development

--- a/docker-compose.macmini.yml
+++ b/docker-compose.macmini.yml
@@ -4,7 +4,7 @@
 # Mac mini through the host's existing Tailscale SSH, then use docker exec.
 #
 # Usage on the Mac mini:
-#   mkdir -p ~/aoc-data/{claude,codex,gitconfig,gh,overnight} ~/projects
+#   mkdir -p ~/aoc-data/{claude,codex,gitconfig,gh,aws,overnight,public} ~/projects
 #   docker compose -f docker-compose.macmini.yml up -d
 #   docker exec -it claude-dev bash -lc 'bash ~/dev-env/scripts/portable/start-claude-portable.sh'
 
@@ -27,17 +27,21 @@ services:
       - ${HOME}/aoc-data/codex:/home/dev/.codex
       - ${HOME}/aoc-data/gitconfig:/home/dev/.config/git
       - ${HOME}/aoc-data/gh:/home/dev/.config/gh
+      - ${HOME}/aoc-data/aws:/home/dev/.aws
       - ${HOME}/aoc-data/overnight:/home/dev/overnight
+      - ${HOME}/aoc-data/public:/srv/public
       - ${HOME}/projects:/home/dev/projects
       - ${HOME}/always-on-claude:/home/dev/dev-env:ro
+      - ${HOME}/.ssh:/home/dev/.ssh:ro
 
     environment:
       - NODE_ENV=development
       - GIT_CONFIG_GLOBAL=/home/dev/.config/git/config
+      - TZ=America/Los_Angeles
 
     command: >
       bash -lc '
-        mkdir -p ~/.claude/debug ~/.claude/commands ~/.codex ~/.config/gh ~/.config/git ~/projects ~/overnight;
+        mkdir -p ~/.claude/debug ~/.claude/commands ~/.codex ~/.config/gh ~/.config/git ~/.aws ~/projects ~/overnight /srv/public;
         touch ~/.config/git/config;
         test -f ~/.claude/claude.json || echo "{}" > ~/.claude/claude.json;
         rm -rf ~/.claude.json && ln -s ~/.claude/claude.json ~/.claude.json;

--- a/docker-compose.macmini.yml
+++ b/docker-compose.macmini.yml
@@ -1,0 +1,74 @@
+# docker-compose.macmini.yml — Mac mini target using host Tailscale SSH.
+#
+# This intentionally does not run Tailscale inside the container. Connect to the
+# Mac mini through the host's existing Tailscale SSH, then use docker exec.
+#
+# Usage on the Mac mini:
+#   mkdir -p ~/aoc-data/{claude,codex,gitconfig,gh,overnight} ~/projects
+#   docker compose -f docker-compose.macmini.yml up -d
+#   docker exec -it claude-dev bash -lc 'bash ~/dev-env/scripts/portable/start-claude-portable.sh'
+
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      labels:
+        org.opencontainers.image.revision: ${AOC_IMAGE_REVISION:-local}
+        org.opencontainers.image.created: ${AOC_IMAGE_CREATED:-local}
+    image: ${DOCKER_IMAGE:-ghcr.io/verkyyi/always-on-claude:latest}
+    container_name: ${CONTAINER_NAME:-claude-dev}
+    hostname: ${CONTAINER_HOSTNAME:-claude-dev}
+    stdin_open: true
+    tty: true
+
+    volumes:
+      - ${HOME}/aoc-data/claude:/home/dev/.claude
+      - ${HOME}/aoc-data/codex:/home/dev/.codex
+      - ${HOME}/aoc-data/gitconfig:/home/dev/.config/git
+      - ${HOME}/aoc-data/gh:/home/dev/.config/gh
+      - ${HOME}/aoc-data/overnight:/home/dev/overnight
+      - ${HOME}/projects:/home/dev/projects
+      - ${HOME}/always-on-claude:/home/dev/dev-env:ro
+
+    environment:
+      - NODE_ENV=development
+      - GIT_CONFIG_GLOBAL=/home/dev/.config/git/config
+
+    command: >
+      bash -lc '
+        mkdir -p ~/.claude/debug ~/.claude/commands ~/.codex ~/.config/gh ~/.config/git ~/projects ~/overnight;
+        touch ~/.config/git/config;
+        test -f ~/.claude/claude.json || echo "{}" > ~/.claude/claude.json;
+        rm -rf ~/.claude.json && ln -s ~/.claude/claude.json ~/.claude.json;
+        touch ~/.claude/remote-settings.json;
+        if [ ! -f ~/.claude/settings.json ]; then
+          printf "%s\n" "{\"permissions\":{\"defaultMode\":\"bypassPermissions\"},\"statusLine\":{\"type\":\"command\",\"command\":\"bash /home/dev/.claude/statusline-command.sh\"},\"mcpServers\":{\"context7\":{\"command\":\"npx\",\"args\":[\"-y\",\"@upstash/context7-mcp\"]},\"fetch\":{\"command\":\"uvx\",\"args\":[\"mcp-server-fetch\"]}}}" > ~/.claude/settings.json;
+        fi;
+        if [ -f ~/dev-env/scripts/runtime/statusline-command.sh ]; then
+          cp ~/dev-env/scripts/runtime/statusline-command.sh ~/.claude/statusline-command.sh;
+          chmod +x ~/.claude/statusline-command.sh;
+        fi;
+        if [ -x ~/dev-env/scripts/runtime/sync-claude-personalization.sh ]; then
+          ~/dev-env/scripts/runtime/sync-claude-personalization.sh >/dev/null || true;
+        fi;
+        if [ -x ~/dev-env/scripts/runtime/sync-codex-personalization.sh ]; then
+          ~/dev-env/scripts/runtime/sync-codex-personalization.sh >/dev/null || true;
+        fi;
+        if [ -f ~/dev-env/scripts/runtime/gh-mcp-env.sh ]; then
+          cp ~/dev-env/scripts/runtime/gh-mcp-env.sh ~/.claude/gh-mcp-env.sh;
+          chmod +x ~/.claude/gh-mcp-env.sh;
+        fi;
+        if [ -f ~/dev-env/scripts/runtime/tmux.conf ]; then
+          cp ~/dev-env/scripts/runtime/tmux.conf ~/.tmux.conf;
+        fi;
+        if [ -f ~/dev-env/scripts/runtime/tmux-status.sh ]; then
+          cp ~/dev-env/scripts/runtime/tmux-status.sh ~/.tmux-status.sh;
+          chmod +x ~/.tmux-status.sh;
+        fi;
+        exec sleep infinity
+      '
+
+    mem_limit: 3g
+    memswap_limit: 4g
+    restart: unless-stopped

--- a/scripts/runtime/aoc-menu-mac.sh
+++ b/scripts/runtime/aoc-menu-mac.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Open the Always-On Claude workspace menu from a macOS host.
+#
+# Intended for a Mac mini reached through host-level SSH/Tailscale SSH. This
+# does not start or configure Tailscale; it only uses the local Docker runtime.
+
+set -euo pipefail
+
+DOCKER="${DOCKER:-/opt/homebrew/bin/docker}"
+REPO="${AOC_REPO:-$HOME/always-on-claude}"
+CONTAINER="${AOC_CONTAINER:-claude-dev}"
+COMPOSE_FILE="${AOC_COMPOSE_FILE:-docker-compose.macmini.yml}"
+
+if ! "$DOCKER" ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  echo "$CONTAINER is not running. Starting it..."
+  cd "$REPO"
+  "$DOCKER" compose -f "$COMPOSE_FILE" up -d
+fi
+
+exec "$DOCKER" exec -it "$CONTAINER" bash -lc \
+  'exec bash "$HOME/dev-env/scripts/portable/start-claude-portable.sh"'

--- a/scripts/runtime/install-macmini-host-tools.sh
+++ b/scripts/runtime/install-macmini-host-tools.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# install-macmini-host-tools.sh — Install Mac mini host CLI tools.
+
+set -euo pipefail
+
+info() { printf '\n=== %s ===\n' "$*"; }
+ok() { printf '  OK: %s\n' "$*"; }
+skip() { printf '  SKIP: %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+HOME_DIR="${AOC_HOME:-$HOME}"
+REPO="${AOC_REPO:-$HOME_DIR/always-on-claude}"
+BREW="${AOC_BREW:-/opt/homebrew/bin/brew}"
+NPM="${AOC_NPM:-/opt/homebrew/bin/npm}"
+AWS_DIR="${AOC_AWS_DIR:-$HOME_DIR/aoc-data/aws}"
+CODEX_HOME="${CODEX_HOME:-$HOME_DIR/.codex}"
+
+[ -x "$BREW" ] || die "Homebrew not found at $BREW"
+[ -x "$NPM" ] || die "npm not found at $NPM"
+[ -d "$REPO" ] || die "Repo not found: $REPO"
+
+info "Codex CLI"
+if ! command -v codex >/dev/null 2>&1; then
+    "$NPM" install -g @openai/codex
+    ok "Installed Codex CLI"
+else
+    skip "Codex CLI already installed"
+fi
+
+if [ -x "$REPO/scripts/runtime/sync-codex-personalization.sh" ]; then
+    CODEX_HOME="$CODEX_HOME" "$REPO/scripts/runtime/sync-codex-personalization.sh" >/dev/null
+    ok "Synced Codex host config"
+fi
+
+info "AWS CLI"
+if ! command -v aws >/dev/null 2>&1; then
+    "$BREW" install awscli
+    ok "Installed AWS CLI"
+else
+    skip "AWS CLI already installed"
+fi
+
+mkdir -p "$AWS_DIR"
+if [ -e "$HOME_DIR/.aws" ] && [ ! -L "$HOME_DIR/.aws" ]; then
+    skip "$HOME_DIR/.aws exists and is not a symlink"
+elif [ -L "$HOME_DIR/.aws" ]; then
+    current_target="$(readlink "$HOME_DIR/.aws")"
+    if [ "$current_target" = "$AWS_DIR" ]; then
+        skip "$HOME_DIR/.aws already points to $AWS_DIR"
+    else
+        die "$HOME_DIR/.aws points to $current_target, expected $AWS_DIR"
+    fi
+else
+    ln -s "$AWS_DIR" "$HOME_DIR/.aws"
+    ok "Linked $HOME_DIR/.aws -> $AWS_DIR"
+fi
+
+info "Verify"
+codex --version
+aws --version

--- a/scripts/runtime/install-macmini-nginx.sh
+++ b/scripts/runtime/install-macmini-nginx.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# install-macmini-nginx.sh — Serve the shared public directory on the tailnet.
+#
+# Runs nginx as a user LaunchAgent on localhost, then publishes it to the
+# tailnet with Tailscale Serve. This avoids privileged port binding on macOS
+# and leaves Tailscale SSH/sshd untouched.
+
+set -euo pipefail
+
+info() { printf '\n=== %s ===\n' "$*"; }
+ok() { printf '  OK: %s\n' "$*"; }
+skip() { printf '  SKIP: %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+HOME_DIR="${AOC_HOME:-$HOME}"
+BREW="${AOC_BREW:-/opt/homebrew/bin/brew}"
+TAILSCALE="${AOC_TAILSCALE:-/Applications/Tailscale.app/Contents/MacOS/Tailscale}"
+if [ ! -x "$TAILSCALE" ] && command -v tailscale >/dev/null 2>&1; then
+    TAILSCALE="$(command -v tailscale)"
+fi
+
+PUBLIC_DIR="${AOC_PUBLIC_DIR:-$HOME_DIR/aoc-data/public}"
+STATE_DIR="${AOC_NGINX_STATE_DIR:-$HOME_DIR/.always-on-claude/nginx}"
+LISTEN_HOST="${AOC_NGINX_LISTEN_HOST:-127.0.0.1}"
+LISTEN_PORT="${AOC_NGINX_PORT:-18080}"
+LABEL="com.always-on-claude.nginx"
+PLIST="$HOME_DIR/Library/LaunchAgents/$LABEL.plist"
+CONFIG="$STATE_DIR/nginx.conf"
+
+[ -x "$BREW" ] || die "Homebrew not found at $BREW"
+[ -x "$TAILSCALE" ] || die "tailscale CLI not found"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+command -v curl >/dev/null 2>&1 || die "curl is required"
+
+info "nginx"
+if ! "$BREW" list nginx >/dev/null 2>&1; then
+    "$BREW" install nginx
+    ok "Installed nginx"
+else
+    skip "nginx already installed"
+fi
+
+NGINX_BIN="$("$BREW" --prefix nginx)/bin/nginx"
+MIME_TYPES="$("$BREW" --prefix)/etc/nginx/mime.types"
+[ -x "$NGINX_BIN" ] || die "nginx binary not found at $NGINX_BIN"
+[ -f "$MIME_TYPES" ] || die "mime.types not found at $MIME_TYPES"
+
+mkdir -p "$PUBLIC_DIR" "$STATE_DIR/logs" "$STATE_DIR/run" "$HOME_DIR/Library/LaunchAgents"
+if [ ! -f "$PUBLIC_DIR/index.html" ]; then
+    printf '%s\n' '<!doctype html><title>always-on-claude</title><h1>always-on-claude</h1>' > "$PUBLIC_DIR/index.html"
+fi
+
+TS_FQDN="$("$TAILSCALE" status --json | jq -r '.Self.DNSName // ""' | sed 's/[.]$//')"
+TS_IP="$("$TAILSCALE" ip -4 | head -1)"
+[ -n "$TS_FQDN" ] && [ "$TS_FQDN" != "null" ] || die "Could not determine Tailscale hostname"
+[ -n "$TS_IP" ] || die "Could not determine Tailscale IPv4 address"
+
+info "nginx config"
+cat > "$CONFIG" <<NGINX
+worker_processes 1;
+error_log $STATE_DIR/logs/error.log warn;
+pid $STATE_DIR/run/nginx.pid;
+
+events {
+    worker_connections 256;
+}
+
+http {
+    include $MIME_TYPES;
+    default_type application/octet-stream;
+
+    access_log $STATE_DIR/logs/access.log;
+    sendfile on;
+    keepalive_timeout 65;
+    server_tokens off;
+
+    server {
+        listen $LISTEN_HOST:$LISTEN_PORT;
+        server_name $TS_FQDN localhost;
+
+        root $PUBLIC_DIR;
+        index index.html;
+
+        location / {
+            try_files \$uri \$uri/ =404;
+        }
+    }
+}
+NGINX
+
+"$NGINX_BIN" -t -c "$CONFIG" >/dev/null
+ok "nginx config valid"
+
+info "LaunchAgent"
+cat > "$PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$NGINX_BIN</string>
+    <string>-c</string>
+    <string>$CONFIG</string>
+    <string>-g</string>
+    <string>daemon off;</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$STATE_DIR/logs/launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>$STATE_DIR/logs/launchd.log</string>
+</dict>
+</plist>
+PLIST
+chmod 644 "$PLIST"
+plutil -lint "$PLIST" >/dev/null
+
+launchctl unload "$PLIST" >/dev/null 2>&1 || true
+launchctl load -w "$PLIST"
+launchctl kickstart -k "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || launchctl start "$LABEL" >/dev/null 2>&1 || true
+ok "nginx LaunchAgent loaded"
+
+for _ in 1 2 3 4 5; do
+    if curl -fsS "http://$LISTEN_HOST:$LISTEN_PORT/" >/dev/null 2>&1; then
+        ok "nginx responding on http://$LISTEN_HOST:$LISTEN_PORT"
+        break
+    fi
+    sleep 1
+done
+
+if ! curl -fsS "http://$LISTEN_HOST:$LISTEN_PORT/" >/dev/null 2>&1; then
+    die "nginx did not become ready on http://$LISTEN_HOST:$LISTEN_PORT"
+fi
+
+info "Tailscale Serve"
+if [ "${AOC_CONFIGURE_TAILSCALE_SERVE:-1}" = "1" ]; then
+    "$TAILSCALE" serve --bg --yes "http://$LISTEN_HOST:$LISTEN_PORT" >/dev/null
+    ok "Tailnet URL: https://$TS_FQDN/"
+else
+    skip "Tailscale Serve configuration disabled"
+fi

--- a/scripts/runtime/install-macmini-schedule-bridge.sh
+++ b/scripts/runtime/install-macmini-schedule-bridge.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# install-macmini-schedule-bridge.sh — Install the macOS schedule bridge.
+#
+# Runs on the Mac mini host. Container sessions write request JSON to the
+# bind-mounted inbox; this LaunchAgent watches the inbox and runs the shared
+# processor with macOS-specific host path and Docker settings.
+
+set -euo pipefail
+
+info() { printf '\n=== %s ===\n' "$*"; }
+ok() { printf '  OK: %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+USER_NAME="${AOC_USER:-$(id -un)}"
+HOME_DIR="${AOC_HOME:-$HOME}"
+REPO="${AOC_REPO:-$HOME_DIR/always-on-claude}"
+SCHEDULE_DIR="${AOC_SCHEDULE_DIR:-$HOME_DIR/.always-on-claude/schedule}"
+PROJECTS_DIR="${AOC_HOST_PROJECTS_DIR:-$HOME_DIR/projects}"
+DOCKER="${AOC_DOCKER:-/opt/homebrew/bin/docker}"
+COMPOSE_FILE="${AOC_DOCKER_COMPOSE_FILE:-docker-compose.macmini.yml}"
+LABEL="com.always-on-claude.schedule-bridge"
+PLIST="$HOME_DIR/Library/LaunchAgents/$LABEL.plist"
+PROCESSOR="$REPO/scripts/runtime/process-schedule-requests.sh"
+LOG_FILE="$SCHEDULE_DIR/logs/launchd.log"
+
+command -v launchctl >/dev/null 2>&1 || die "launchctl is required"
+command -v jq >/dev/null 2>&1 || die "jq is required"
+[ -x "$DOCKER" ] || die "Docker not found at $DOCKER"
+[ -x "$PROCESSOR" ] || die "Missing executable processor: $PROCESSOR"
+[ -f "$REPO/$COMPOSE_FILE" ] || die "Missing compose file: $REPO/$COMPOSE_FILE"
+
+info "Schedule bridge directories"
+for dir in inbox processing jobs logs status; do
+    mkdir -p "$SCHEDULE_DIR/$dir"
+done
+mkdir -p "$PROJECTS_DIR" "$HOME_DIR/Library/LaunchAgents"
+chmod 700 "$SCHEDULE_DIR" "$SCHEDULE_DIR/inbox" "$SCHEDULE_DIR/processing" "$SCHEDULE_DIR/jobs"
+chmod 755 "$SCHEDULE_DIR/logs" "$SCHEDULE_DIR/status"
+ok "Directories ready"
+
+info "LaunchAgent"
+cat > "$PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$PROCESSOR</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$REPO</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>$HOME_DIR</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>AOC_USER</key>
+    <string>$USER_NAME</string>
+    <key>DEV_ENV</key>
+    <string>$REPO</string>
+    <key>AOC_SCHEDULE_DIR</key>
+    <string>$SCHEDULE_DIR</string>
+    <key>AOC_DOCKER</key>
+    <string>$DOCKER</string>
+    <key>AOC_DOCKER_COMPOSE_FILE</key>
+    <string>$COMPOSE_FILE</string>
+    <key>AOC_DOCKER_SERVICE</key>
+    <string>dev</string>
+    <key>AOC_DOCKER_EXEC_PREFIX</key>
+    <string></string>
+    <key>AOC_CONTAINER_PROJECTS_DIR</key>
+    <string>/home/dev/projects</string>
+    <key>AOC_HOST_PROJECTS_DIR</key>
+    <string>$PROJECTS_DIR</string>
+    <key>AOC_AT_BACKEND</key>
+    <string>launchd</string>
+    <key>AOC_CRON_BACKEND</key>
+    <string>launchd</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>60</integer>
+  <key>WatchPaths</key>
+  <array>
+    <string>$SCHEDULE_DIR/inbox</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>$LOG_FILE</string>
+  <key>StandardErrorPath</key>
+  <string>$LOG_FILE</string>
+</dict>
+</plist>
+PLIST
+chmod 644 "$PLIST"
+plutil -lint "$PLIST" >/dev/null
+ok "Wrote $PLIST"
+
+launchctl unload "$PLIST" >/dev/null 2>&1 || true
+launchctl load -w "$PLIST"
+launchctl kickstart -k "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || launchctl start "$LABEL" >/dev/null 2>&1 || true
+ok "LaunchAgent loaded"
+
+info "Existing recurring jobs"
+AOC_USER="$USER_NAME" \
+DEV_ENV="$REPO" \
+AOC_SCHEDULE_DIR="$SCHEDULE_DIR" \
+AOC_DOCKER="$DOCKER" \
+AOC_DOCKER_COMPOSE_FILE="$COMPOSE_FILE" \
+AOC_DOCKER_SERVICE="dev" \
+AOC_DOCKER_EXEC_PREFIX="" \
+AOC_CONTAINER_PROJECTS_DIR="/home/dev/projects" \
+AOC_HOST_PROJECTS_DIR="$PROJECTS_DIR" \
+AOC_AT_BACKEND="launchd" \
+AOC_CRON_BACKEND="launchd" \
+    "$PROCESSOR" --reinstall-cron
+ok "Recurring jobs reconciled"
+
+info "Process pending requests"
+AOC_USER="$USER_NAME" \
+DEV_ENV="$REPO" \
+AOC_SCHEDULE_DIR="$SCHEDULE_DIR" \
+AOC_DOCKER="$DOCKER" \
+AOC_DOCKER_COMPOSE_FILE="$COMPOSE_FILE" \
+AOC_DOCKER_SERVICE="dev" \
+AOC_DOCKER_EXEC_PREFIX="" \
+AOC_CONTAINER_PROJECTS_DIR="/home/dev/projects" \
+AOC_HOST_PROJECTS_DIR="$PROJECTS_DIR" \
+AOC_AT_BACKEND="launchd" \
+AOC_CRON_BACKEND="launchd" \
+    "$PROCESSOR"
+ok "Schedule bridge ready"

--- a/scripts/runtime/install-macmini-services.sh
+++ b/scripts/runtime/install-macmini-services.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 
 REPO="${AOC_REPO:-$HOME/always-on-claude}"
 
+bash "$REPO/scripts/runtime/install-macmini-host-tools.sh"
 bash "$REPO/scripts/runtime/install-macmini-schedule-bridge.sh"
 bash "$REPO/scripts/runtime/install-macmini-nginx.sh"

--- a/scripts/runtime/install-macmini-services.sh
+++ b/scripts/runtime/install-macmini-services.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# install-macmini-services.sh — Install Mac mini host services.
+
+set -euo pipefail
+
+REPO="${AOC_REPO:-$HOME/always-on-claude}"
+
+bash "$REPO/scripts/runtime/install-macmini-schedule-bridge.sh"
+bash "$REPO/scripts/runtime/install-macmini-nginx.sh"

--- a/scripts/runtime/process-schedule-requests.sh
+++ b/scripts/runtime/process-schedule-requests.sh
@@ -16,6 +16,14 @@ fi
 TARGET_GROUP="$(id -gn "$TARGET_USER")"
 DEV_ENV="${DEV_ENV:-$TARGET_HOME/dev-env}"
 SCHEDULE_DIR="${AOC_SCHEDULE_DIR:-$TARGET_HOME/.always-on-claude/schedule}"
+DOCKER_BIN="${AOC_DOCKER:-docker}"
+DOCKER_COMPOSE_FILE="${AOC_DOCKER_COMPOSE_FILE-}"
+DOCKER_SERVICE="${AOC_DOCKER_SERVICE:-dev}"
+DOCKER_EXEC_PREFIX="${AOC_DOCKER_EXEC_PREFIX-sudo --preserve-env=HOME}"
+CONTAINER_PROJECTS_DIR="${AOC_CONTAINER_PROJECTS_DIR:-/home/dev/projects}"
+HOST_PROJECTS_DIR="${AOC_HOST_PROJECTS_DIR:-$TARGET_HOME/projects}"
+AT_BACKEND="${AOC_AT_BACKEND:-at}"
+CRON_BACKEND="${AOC_CRON_BACKEND:-crontab}"
 
 INBOX_DIR="$SCHEDULE_DIR/inbox"
 PROCESSING_DIR="$SCHEDULE_DIR/processing"
@@ -23,6 +31,7 @@ JOBS_DIR="$SCHEDULE_DIR/jobs"
 LOG_DIR="$SCHEDULE_DIR/logs"
 STATUS_DIR="$SCHEDULE_DIR/status"
 LOCK_FILE="$SCHEDULE_DIR/.processor.lock"
+LOCK_DIR="$SCHEDULE_DIR/.processor.lockdir"
 
 now_utc() {
     date -u +%Y-%m-%dT%H:%M:%SZ
@@ -33,7 +42,15 @@ valid_id() {
 }
 
 container_cwd_ok() {
-    [[ "$1" == "/home/dev/projects" || "$1" == /home/dev/projects/* ]]
+    [[ "$1" == "$CONTAINER_PROJECTS_DIR" || "$1" == "$CONTAINER_PROJECTS_DIR"/* ]]
+}
+
+host_path_for_cwd() {
+    local cwd="$1"
+    local relative
+
+    relative="${cwd#"$CONTAINER_PROJECTS_DIR"}"
+    printf '%s%s\n' "$HOST_PROJECTS_DIR" "$relative"
 }
 
 cron_field_ok() {
@@ -144,6 +161,10 @@ create_job_script() {
         printf 'set -uo pipefail\n'
         printf 'export HOME=%q\n' "$TARGET_HOME"
         printf 'DEV_ENV=%q\n' "$DEV_ENV"
+        printf 'DOCKER_BIN=%q\n' "$DOCKER_BIN"
+        printf 'DOCKER_COMPOSE_FILE=%q\n' "$DOCKER_COMPOSE_FILE"
+        printf 'DOCKER_SERVICE=%q\n' "$DOCKER_SERVICE"
+        printf 'DOCKER_EXEC_PREFIX=%q\n' "$DOCKER_EXEC_PREFIX"
         printf 'JOB_ID=%q\n' "$id"
         printf 'CWD=%q\n' "$cwd"
         printf 'COMMAND=%q\n' "$command"
@@ -211,8 +232,22 @@ update_status() {
 
     cd "$DEV_ENV" || exit 127
 
+    compose_args=(compose)
+    if [[ -n "$DOCKER_COMPOSE_FILE" ]]; then
+        compose_args+=(-f "$DOCKER_COMPOSE_FILE")
+    fi
+
+    exec_prefix=()
+    if [[ -n "$DOCKER_EXEC_PREFIX" ]]; then
+        read -r -a exec_prefix <<< "$DOCKER_EXEC_PREFIX"
+    fi
+
     set +e
-    sudo --preserve-env=HOME docker compose exec -T -w "$CWD" dev bash -lc "$COMMAND"
+    if [[ ${#exec_prefix[@]} -gt 0 ]]; then
+        "${exec_prefix[@]}" "$DOCKER_BIN" "${compose_args[@]}" exec -T -w "$CWD" "$DOCKER_SERVICE" bash -lc "$COMMAND"
+    else
+        "$DOCKER_BIN" "${compose_args[@]}" exec -T -w "$CWD" "$DOCKER_SERVICE" bash -lc "$COMMAND"
+    fi
     rc=$?
     set -e
 
@@ -232,6 +267,180 @@ JOB
     chmod 700 "$job_script"
 }
 
+parse_launchd_time_spec() {
+    local time_spec="$1"
+
+    python3 - "$time_spec" <<'PY'
+import datetime as dt
+import re
+import sys
+
+spec = sys.argv[1].strip().lower()
+now = dt.datetime.now().astimezone()
+
+def emit(value):
+    if value <= now:
+        value = value + dt.timedelta(days=1)
+    print(f"{int(value.timestamp())}\t{value.isoformat(timespec='seconds')}")
+
+match = re.fullmatch(r"now(?:\s*\+\s*(\d+)\s*(minute|minutes|min|mins|hour|hours|day|days))?", spec)
+if match:
+    count = int(match.group(1) or "0")
+    unit = match.group(2) or "minutes"
+    if unit.startswith("min"):
+        due = now + dt.timedelta(minutes=count)
+    elif unit.startswith("hour"):
+        due = now + dt.timedelta(hours=count)
+    else:
+        due = now + dt.timedelta(days=count)
+    print(f"{int(due.timestamp())}\t{due.isoformat(timespec='seconds')}")
+    raise SystemExit(0)
+
+match = re.fullmatch(r"(?:tomorrow\s+)?(\d{1,2}):(\d{2})(?:\s*(today|tomorrow))?", spec)
+if match:
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+    day_word = match.group(3)
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise SystemExit("invalid clock time")
+    due = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if spec.startswith("tomorrow") or day_word == "tomorrow":
+        due += dt.timedelta(days=1)
+    emit(due)
+    raise SystemExit(0)
+
+for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M"):
+    try:
+        parsed = dt.datetime.strptime(spec, fmt).replace(tzinfo=now.tzinfo)
+    except ValueError:
+        continue
+    print(f"{int(parsed.timestamp())}\t{parsed.isoformat(timespec='seconds')}")
+    raise SystemExit(0)
+
+raise SystemExit("unsupported macOS launchd time spec")
+PY
+}
+
+schedule_launchd_at_job() {
+    local request="$1"
+    local id="$2"
+    local time_spec="$3"
+    local label="$4"
+    local status_file="$5"
+    local log_file="$6"
+    local due_info due_epoch due_at tmp
+
+    if ! due_info=$(parse_launchd_time_spec "$time_spec" 2>&1); then
+        update_status_file "$status_file" "rejected"
+        tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+        jq --arg reason "$due_info" '.reason = $reason' "$status_file" > "$tmp"
+        mv "$tmp" "$status_file"
+        warn "launchd rejected $id: $due_info"
+        return 0
+    fi
+
+    IFS=$'\t' read -r due_epoch due_at <<< "$due_info"
+    tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+    jq \
+        --arg status "scheduled" \
+        --arg updated_at "$(now_utc)" \
+        --arg host_at_job_id "launchd:$id" \
+        --argjson host_due_epoch "$due_epoch" \
+        --arg host_due_at "$due_at" \
+        --arg log_file "$log_file" \
+        --arg job_label "$label" \
+        '.status = $status
+         | .updated_at = $updated_at
+         | .host_at_job_id = $host_at_job_id
+         | .host_due_epoch = $host_due_epoch
+         | .host_due_at = $host_due_at
+         | .log_file = $log_file
+         | .label = $job_label' \
+        "$status_file" > "$tmp"
+    mv "$tmp" "$status_file"
+
+    ok "Scheduled $id for $due_at via launchd bridge"
+    rm -f "$request"
+}
+
+cron_due_now() {
+    local schedule="$1"
+    local last_started_at="${2:-}"
+
+    python3 - "$schedule" "$last_started_at" <<'PY'
+import datetime as dt
+import sys
+
+schedule = sys.argv[1]
+last_started_at = sys.argv[2]
+now = dt.datetime.now().astimezone()
+utc_minute = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M")
+
+if last_started_at.startswith(utc_minute):
+    raise SystemExit(1)
+
+fields = schedule.split()
+if len(fields) != 5:
+    raise SystemExit(1)
+
+def expand(field, low, high, normalize=None):
+    values = set()
+    for part in field.split(","):
+        if not part:
+            raise ValueError("empty cron field")
+        if "/" in part:
+            base, step_s = part.split("/", 1)
+            step = int(step_s)
+            if step < 1:
+                raise ValueError("invalid step")
+        else:
+            base = part
+            step = 1
+
+        if base == "*":
+            start, end = low, high
+        elif "-" in base:
+            start_s, end_s = base.split("-", 1)
+            start, end = int(start_s), int(end_s)
+        else:
+            start = end = int(base)
+
+        for value in range(start, end + 1, step):
+            if normalize:
+                value = normalize(value)
+            if low <= value <= high:
+                values.add(value)
+    return values
+
+def dow(value):
+    return 0 if value == 7 else value
+
+try:
+    minute = expand(fields[0], 0, 59)
+    hour = expand(fields[1], 0, 23)
+    dom = expand(fields[2], 1, 31)
+    month = expand(fields[3], 1, 12)
+    day = expand(fields[4], 0, 6, dow)
+except Exception:
+    raise SystemExit(1)
+
+dom_restricted = fields[2] != "*"
+dow_restricted = fields[4] != "*"
+cron_dow = (now.weekday() + 1) % 7
+
+basic = now.minute in minute and now.hour in hour and now.month in month
+if not basic:
+    raise SystemExit(1)
+
+if dom_restricted and dow_restricted:
+    due = now.day in dom or cron_dow in day
+else:
+    due = now.day in dom and cron_dow in day
+
+raise SystemExit(0 if due else 1)
+PY
+}
+
 process_at_request() {
     local request="$1"
     local id time_spec cwd command label
@@ -249,8 +458,10 @@ process_at_request() {
     has_newline "$time_spec" && { reject_request "$request" "Time spec must be one line"; return 0; }
     container_cwd_ok "$cwd" || { reject_request "$request" "cwd must be under /home/dev/projects"; return 0; }
 
-    if [[ ! -d "$cwd" ]]; then
-        reject_request "$request" "cwd does not exist on host: $cwd"
+    local host_cwd
+    host_cwd="$(host_path_for_cwd "$cwd")"
+    if [[ ! -d "$host_cwd" ]]; then
+        reject_request "$request" "cwd does not exist on host: $host_cwd"
         return 0
     fi
 
@@ -273,6 +484,11 @@ process_at_request() {
     mv "$tmp" "$status_file"
 
     create_job_script "$id" "$cwd" "$command" "$status_file" "$log_file" "$job_script" false
+
+    if [[ "$AT_BACKEND" == "launchd" ]]; then
+        schedule_launchd_at_job "$request" "$id" "$time_spec" "$label" "$status_file" "$log_file"
+        return 0
+    fi
 
     if ! at_output=$(printf '/bin/bash %q\n' "$job_script" | at -M "$time_spec" 2>&1); then
         update_status_file "$status_file" "rejected"
@@ -366,10 +582,14 @@ process_cron_request() {
     has_newline "$schedule" && { reject_request "$request" "Cron schedule must be one line"; return 0; }
     cron_spec_ok "$schedule" || { reject_request "$request" "Cron schedule must be exactly five valid fields"; return 0; }
     container_cwd_ok "$cwd" || { reject_request "$request" "cwd must be under /home/dev/projects"; return 0; }
-    command -v crontab >/dev/null 2>&1 || { reject_request "$request" "crontab is not installed on the host"; return 0; }
+    if [[ "$CRON_BACKEND" != "launchd" ]]; then
+        command -v crontab >/dev/null 2>&1 || { reject_request "$request" "crontab is not installed on the host"; return 0; }
+    fi
 
-    if [[ ! -d "$cwd" ]]; then
-        reject_request "$request" "cwd does not exist on host: $cwd"
+    local host_cwd
+    host_cwd="$(host_path_for_cwd "$cwd")"
+    if [[ ! -d "$host_cwd" ]]; then
+        reject_request "$request" "cwd does not exist on host: $host_cwd"
         return 0
     fi
 
@@ -392,7 +612,11 @@ process_cron_request() {
     mv "$tmp" "$status_file"
 
     create_job_script "$id" "$cwd" "$command" "$status_file" "$log_file" "$job_script" true
-    install_crontab_entry "$id" "$schedule" "$job_script"
+    if [[ "$CRON_BACKEND" == "launchd" ]]; then
+        :
+    else
+        install_crontab_entry "$id" "$schedule" "$job_script"
+    fi
 
     tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
     jq \
@@ -400,10 +624,12 @@ process_cron_request() {
         --arg updated_at "$(now_utc)" \
         --arg log_file "$log_file" \
         --arg job_label "$label" \
+        --arg host_cron_backend "$CRON_BACKEND" \
         '.status = $status
          | .updated_at = $updated_at
          | .log_file = $log_file
-         | .label = $job_label' \
+         | .label = $job_label
+         | .host_cron_backend = $host_cron_backend' \
         "$status_file" > "$tmp"
     mv "$tmp" "$status_file"
 
@@ -412,7 +638,7 @@ process_cron_request() {
 
 process_cancel_request() {
     local request="$1"
-    local id target_id status_file current_status action at_job_id tmp
+    local id target_id status_file current_status action at_job_id host_cron_backend tmp
 
     id=$(jq -r '.id // empty' "$request")
     target_id=$(jq -r '.target_id // empty' "$request")
@@ -436,10 +662,15 @@ process_cancel_request() {
     fi
 
     if [[ "$action" == "cron" ]]; then
-        remove_crontab_entry "$target_id"
+        host_cron_backend=$(jq -r '.host_cron_backend // empty' "$status_file")
+        if [[ "$host_cron_backend" != "launchd" ]]; then
+            remove_crontab_entry "$target_id"
+        fi
     else
         at_job_id=$(jq -r '.host_at_job_id // empty' "$status_file")
-        if [[ -n "$at_job_id" ]]; then
+        if [[ "$at_job_id" == launchd:* ]]; then
+            :
+        elif [[ -n "$at_job_id" ]]; then
             if ! atrm "$at_job_id" 2>/dev/null; then
                 reject_request "$request" "atrm failed for host at job $at_job_id"
                 return 0
@@ -458,6 +689,129 @@ process_cancel_request() {
 
     write_status_from_request "$request" "succeeded"
     ok "Canceled $target_id"
+}
+
+run_due_launchd_at_jobs() {
+    [[ "$AT_BACKEND" == "launchd" ]] || return 0
+
+    local now status_file id action status due job_script
+    now=$(date +%s)
+
+    shopt -s nullglob
+    for status_file in "$STATUS_DIR"/*.json; do
+        action=$(jq -r '.action // empty' "$status_file" 2>/dev/null || true)
+        status=$(jq -r '.status // empty' "$status_file" 2>/dev/null || true)
+        due=$(jq -r '.host_due_epoch // empty' "$status_file" 2>/dev/null || true)
+        id=$(jq -r '.id // empty' "$status_file" 2>/dev/null || true)
+
+        [[ "$action" == "at" && "$status" == "scheduled" && "$due" =~ ^[0-9]+$ ]] || continue
+        (( due <= now )) || continue
+        valid_id "$id" || continue
+
+        job_script="$JOBS_DIR/$id.sh"
+        if [[ -x "$job_script" ]]; then
+            bash "$job_script" || true
+        else
+            update_status_file "$status_file" "failed" 127
+            warn "Missing job script for due job $id: $job_script"
+        fi
+    done
+}
+
+run_due_launchd_cron_jobs() {
+    [[ "$CRON_BACKEND" == "launchd" ]] || return 0
+
+    local status_file id action status schedule last_started_at job_script
+
+    shopt -s nullglob
+    for status_file in "$STATUS_DIR"/*.json; do
+        action=$(jq -r '.action // empty' "$status_file" 2>/dev/null || true)
+        status=$(jq -r '.status // empty' "$status_file" 2>/dev/null || true)
+        schedule=$(jq -r '.schedule // empty' "$status_file" 2>/dev/null || true)
+        last_started_at=$(jq -r '.last_started_at // empty' "$status_file" 2>/dev/null || true)
+        id=$(jq -r '.id // empty' "$status_file" 2>/dev/null || true)
+
+        [[ "$action" == "cron" && "$status" == "scheduled" ]] || continue
+        valid_id "$id" || continue
+        cron_spec_ok "$schedule" || continue
+        cron_due_now "$schedule" "$last_started_at" || continue
+
+        job_script="$JOBS_DIR/$id.sh"
+        if [[ -x "$job_script" ]]; then
+            bash "$job_script" || true
+        else
+            update_status_file "$status_file" "failed" 127
+            warn "Missing job script for recurring job $id: $job_script"
+        fi
+    done
+}
+
+reinstall_cron_from_status() {
+    mkdir -p "$INBOX_DIR" "$PROCESSING_DIR" "$JOBS_DIR" "$LOG_DIR" "$STATUS_DIR"
+
+    local status_file id action status schedule cwd command label host_cwd log_file job_script tmp
+
+    shopt -s nullglob
+    for status_file in "$STATUS_DIR"/*.json; do
+        action=$(jq -r '.action // empty' "$status_file" 2>/dev/null || true)
+        status=$(jq -r '.status // empty' "$status_file" 2>/dev/null || true)
+        [[ "$action" == "cron" && "$status" == "scheduled" ]] || continue
+
+        id=$(jq -r '.id // empty' "$status_file")
+        schedule=$(jq -r '.schedule // empty' "$status_file")
+        cwd=$(jq -r '.cwd // empty' "$status_file")
+        command=$(jq -r '.command // empty' "$status_file")
+        label=$(jq -r '.label // empty' "$status_file")
+
+        valid_id "$id" || { warn "Skipping cron status with invalid id: $status_file"; continue; }
+        cron_spec_ok "$schedule" || { warn "Skipping $id with invalid cron schedule"; continue; }
+        container_cwd_ok "$cwd" || { warn "Skipping $id with invalid cwd: $cwd"; continue; }
+
+        host_cwd="$(host_path_for_cwd "$cwd")"
+        if [[ ! -d "$host_cwd" ]]; then
+            warn "Skipping $id because host cwd is missing: $host_cwd"
+            continue
+        fi
+
+        log_file="$LOG_DIR/$id.log"
+        job_script="$JOBS_DIR/$id.sh"
+        create_job_script "$id" "$cwd" "$command" "$status_file" "$log_file" "$job_script" true
+        if [[ "$CRON_BACKEND" != "launchd" ]]; then
+            install_crontab_entry "$id" "$schedule" "$job_script"
+        fi
+
+        tmp=$(mktemp "$STATUS_DIR/.${id}.tmp.XXXXXX")
+        jq \
+            --arg updated_at "$(now_utc)" \
+            --arg log_file "$log_file" \
+            --arg job_label "$label" \
+            --arg host_cron_backend "$CRON_BACKEND" \
+            '.updated_at = $updated_at
+             | .log_file = $log_file
+             | .label = $job_label
+             | .host_cron_backend = $host_cron_backend' \
+            "$status_file" > "$tmp"
+        mv "$tmp" "$status_file"
+
+        ok "Reinstalled recurring job $id"
+    done
+}
+
+acquire_lock() {
+    if command -v flock >/dev/null 2>&1; then
+        exec 9>"$LOCK_FILE"
+        if ! flock -n 9; then
+            warn "Another schedule processor is already running"
+            exit 0
+        fi
+        return 0
+    fi
+
+    if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+        warn "Another schedule processor is already running"
+        exit 0
+    fi
+    trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
 }
 
 process_request() {
@@ -491,16 +845,23 @@ process_request() {
 }
 
 main() {
+    case "${1:-}" in
+        --run-due-at)
+            run_due_launchd_at_jobs
+            return 0
+            ;;
+        --reinstall-cron)
+            reinstall_cron_from_status
+            return 0
+            ;;
+    esac
+
     mkdir -p "$INBOX_DIR" "$PROCESSING_DIR" "$JOBS_DIR" "$LOG_DIR" "$STATUS_DIR"
     if [[ $EUID -eq 0 ]]; then
         chown -R "$TARGET_USER:$TARGET_GROUP" "$SCHEDULE_DIR"
     fi
 
-    exec 9>"$LOCK_FILE"
-    if ! flock -n 9; then
-        warn "Another schedule processor is already running"
-        exit 0
-    fi
+    acquire_lock
 
     shopt -s nullglob
     local request work
@@ -510,6 +871,9 @@ main() {
         process_request "$work" || true
         rm -f "$work"
     done
+
+    run_due_launchd_at_jobs
+    run_due_launchd_cron_jobs
 }
 
 main "$@"

--- a/scripts/runtime/sync-codex-personalization.sh
+++ b/scripts/runtime/sync-codex-personalization.sh
@@ -93,7 +93,12 @@ sync_managed_mcp_config() {
     if [[ -s "$merged" ]]; then
         printf '\n\n' >> "$merged"
     fi
-    cat "$SOURCE_HOME/mcp-config.toml" >> "$merged"
+    awk -v codex_home="$CODEX_HOME" '
+        {
+            gsub("/home/dev/.codex", codex_home)
+            print
+        }
+    ' "$SOURCE_HOME/mcp-config.toml" >> "$merged"
 
     if [[ ! -f "$CONFIG_FILE" ]] || ! cmp -s "$merged" "$CONFIG_FILE"; then
         mv "$merged" "$CONFIG_FILE"

--- a/scripts/runtime/update-macmini.sh
+++ b/scripts/runtime/update-macmini.sh
@@ -53,6 +53,17 @@ AOC_IMAGE_REVISION="$revision" AOC_IMAGE_CREATED="$created" \
   "$DOCKER" compose -f "$COMPOSE_FILE" up -d --force-recreate dev
 ok "Container recreated"
 
+info "Host services"
+if [ -x "$REPO/scripts/runtime/install-macmini-services.sh" ]; then
+  AOC_REPO="$REPO" \
+  AOC_DOCKER="$DOCKER" \
+  AOC_DOCKER_COMPOSE_FILE="$COMPOSE_FILE" \
+    bash "$REPO/scripts/runtime/install-macmini-services.sh"
+  ok "Mac mini host services installed"
+else
+  ok "No Mac mini host service installer found"
+fi
+
 info "Verify"
 "$DOCKER" inspect "$CONTAINER" --format \
   '  Image={{.Image}} Started={{.State.StartedAt}}'

--- a/scripts/runtime/update-macmini.sh
+++ b/scripts/runtime/update-macmini.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# update-macmini.sh — Update the Mac mini local deployment from source.
+#
+# Runs on the Mac mini host. It updates the repo, builds the Docker image
+# locally from the current checkout, and recreates the container with the same
+# persistent bind mounts.
+
+set -euo pipefail
+
+DOCKER="${DOCKER:-/opt/homebrew/bin/docker}"
+REPO="${AOC_REPO:-$HOME/always-on-claude}"
+COMPOSE_FILE="${AOC_COMPOSE_FILE:-docker-compose.macmini.yml}"
+CONTAINER="${AOC_CONTAINER:-claude-dev}"
+
+info() { printf '\n=== %s ===\n' "$*"; }
+ok() { printf '  OK: %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v "$DOCKER" >/dev/null 2>&1 || die "Docker not found at $DOCKER"
+[ -d "$REPO/.git" ] || die "Repo not found: $REPO"
+
+cd "$REPO"
+
+info "Preflight"
+"$DOCKER" info >/dev/null 2>&1 || die "Docker daemon is not running"
+ok "Docker is running"
+
+if "$DOCKER" ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  sessions=$("$DOCKER" exec "$CONTAINER" bash -lc \
+    'tmux list-sessions -F "#{session_name}" 2>/dev/null || true')
+  if [ -n "$sessions" ]; then
+    printf 'Active tmux sessions inside %s:\n%s\n' "$CONTAINER" "$sessions"
+    die "Stop or detach work before updating; recreating the container would end these sessions."
+  fi
+fi
+ok "No active tmux sessions inside container"
+
+info "Repository"
+git fetch origin main
+git pull --ff-only
+revision=$(git rev-parse HEAD)
+short_revision=$(git rev-parse --short HEAD)
+created=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+ok "Repo at $short_revision"
+
+info "Build"
+AOC_IMAGE_REVISION="$revision" AOC_IMAGE_CREATED="$created" \
+  "$DOCKER" compose -f "$COMPOSE_FILE" build --pull dev
+ok "Image built from $short_revision"
+
+info "Restart"
+AOC_IMAGE_REVISION="$revision" AOC_IMAGE_CREATED="$created" \
+  "$DOCKER" compose -f "$COMPOSE_FILE" up -d --force-recreate dev
+ok "Container recreated"
+
+info "Verify"
+"$DOCKER" inspect "$CONTAINER" --format \
+  '  Image={{.Image}} Started={{.State.StartedAt}}'
+"$DOCKER" image inspect ghcr.io/verkyyi/always-on-claude:latest --format \
+  '  Created={{.Created}} Revision={{index .Config.Labels "org.opencontainers.image.revision"}}'
+"$DOCKER" exec "$CONTAINER" bash -lc \
+  'claude --version; node --version; gh --version | head -1; git --version'
+
+info "Cleanup"
+"$DOCKER" image prune -f >/dev/null 2>&1 || true
+ok "Done"


### PR DESCRIPTION
## Summary
- add a Mac mini compose overlay that uses host Tailscale SSH and persistent bind mounts
- add a host-side menu launcher for the local Docker container
- add a Mac mini update script that fast-forwards the repo, rebuilds locally, recreates the container, and verifies versions

## Validation
- docker compose -f docker-compose.macmini.yml config
- bash -n scripts/runtime/aoc-menu-mac.sh scripts/runtime/update-macmini.sh
- shellcheck -S warning scripts/runtime/aoc-menu-mac.sh scripts/runtime/update-macmini.sh
- deployed and verified on macmini at repo revision 7101939 before publishing
