### PR TITLE
Auto-install per-project Python deps on login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN printf '\nalias cc="claude --dangerously-skip-permissions"\nalias cx="codex 
 
 # Auto-install per-project Python deps on login (runs for `bash -lc` in cron jobs)
 # Uses a cache marker so re-install only happens when requirements.txt changes.
+# hadolint ignore=SC2016
 RUN printf '\n# Auto-install per-project Python requirements\nfor _req in "$HOME"/projects/*/requirements.txt; do\n    [ -f "$_req" ] || continue\n    _marker="$HOME/.cache/aoc/$(basename "$(dirname "$_req")").installed"\n    if [ ! -f "$_marker" ] || [ "$_req" -nt "$_marker" ]; then\n        mkdir -p "$(dirname "$_marker")"\n        pip install -q --user --break-system-packages -r "$_req" >/dev/null 2>&1 && touch "$_marker" || true\n    fi\ndone\nunset _req _marker\n' >> /home/dev/.profile
 
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,8 @@ RUN playwright install chromium
 # Shell aliases
 RUN printf '\nalias cc="claude --dangerously-skip-permissions"\nalias cx="codex --dangerously-bypass-approvals-and-sandbox"\nalias gs="git status"\nalias gl="git log --oneline -20"\n' >> /home/dev/.bashrc
 
+# Auto-install per-project Python deps on login (runs for `bash -lc` in cron jobs)
+# Uses a cache marker so re-install only happens when requirements.txt changes.
+RUN printf '\n# Auto-install per-project Python requirements\nfor _req in "$HOME"/projects/*/requirements.txt; do\n    [ -f "$_req" ] || continue\n    _marker="$HOME/.cache/aoc/$(basename "$(dirname "$_req")").installed"\n    if [ ! -f "$_marker" ] || [ "$_req" -nt "$_marker" ]; then\n        mkdir -p "$(dirname "$_marker")"\n        pip install -q --user --break-system-packages -r "$_req" >/dev/null 2>&1 && touch "$_marker" || true\n    fi\ndone\nunset _req _marker\n' >> /home/dev/.profile
+
 CMD ["bash"]


### PR DESCRIPTION
## Summary
- Appends a hook to `/home/dev/.profile` that pip-installs each `~/projects/*/requirements.txt` on login shells.
- Runs for `bash -lc` invocations (including the cron wrapper used by `aoc-schedule`) — `.bashrc` would be skipped by its own non-interactive guard.
- Uses a cache marker under `~/.cache/aoc/<project>.installed` so reinstall only runs when the requirements file changes or the container is rebuilt.

## Why
After the Mac mini migration, `brief.py` in `~/projects/dashboard/scripts/daily_brief/` started failing cron runs with `ModuleNotFoundError: No module named 'yaml'` / `feedparser`. A per-user `pip install --user` fixes it until the container is rebuilt, at which point `~/.local/` is wiped. This hook makes the install self-heal after rebuilds without baking dashboard-specific deps into the base image.

## Test plan
- [x] Live-applied the hook to the running container's `~/.profile` and verified:
  - Cold login: ~0.39s (installs, touches marker)
  - Warm login: ~0.08s (marker present, skipped)
  - `python3 -c 'import yaml, feedparser'` succeeds
  - Existing `requirements.txt` in `agent-team-playground` is also picked up (no false positives)
- [ ] After merge: rebuild image (`docker compose -f docker-compose.macmini.yml build`) and verify hook is baked in.