### PR TITLE
[codex] Add Claude repo status line counts

### DIFF
--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -381,7 +381,7 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
     ok "Installed statusline-command.sh"
 
     # Build desired user-scope settings
-    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"},"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}'
+    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"},"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /home/dev/.claude/hooks/session-git-context.sh","timeout":20}]}]},"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"fetch":{"command":"uvx","args":["mcp-server-fetch"]}}}'
 
     # Merge heartbeat hooks if configured (use jq --arg for safe escaping)
     if [[ -n "${AOC_HEARTBEAT_URL:-}" && -n "${AOC_HEARTBEAT_TOKEN:-}" ]]; then
@@ -393,7 +393,11 @@ if [[ -f "$DEV_ENV/scripts/runtime/statusline-command.sh" ]]; then
                 Stop: [{matcher: "", hooks: [{type: "http", url: $url, headers: {Authorization: ("Bearer " + $token)}}]}],
                 SessionStart: [{matcher: "", hooks: [{type: "http", url: $url, headers: {Authorization: ("Bearer " + $token)}}]}]
             }}')
-        desired=$(echo "$desired" | jq --argjson hb "$heartbeat_hooks" '. * $hb')
+        desired=$(echo "$desired" | jq --argjson hb "$heartbeat_hooks" '
+            .hooks.Notification = ((.hooks.Notification // []) + ($hb.hooks.Notification // []))
+            | .hooks.Stop = ((.hooks.Stop // []) + ($hb.hooks.Stop // []))
+            | .hooks.SessionStart = ((.hooks.SessionStart // []) + ($hb.hooks.SessionStart // []))
+        ')
         ok "Added heartbeat hooks to settings"
     fi
 

--- a/scripts/portable/entrypoint.sh
+++ b/scripts/portable/entrypoint.sh
@@ -58,7 +58,7 @@ fi
 
 # settings.json — set up default settings if not present
 if [[ ! -f /home/dev/.claude/settings.json ]]; then
-    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"}}'
+    desired='{"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"bash /home/dev/.claude/statusline-command.sh"},"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"bash /home/dev/.claude/hooks/session-git-context.sh","timeout":20}]}]}}'
     echo "$desired" | jq . > /home/dev/.claude/settings.json 2>/dev/null || echo "$desired" > /home/dev/.claude/settings.json
     ok "Created default settings.json"
 fi

--- a/scripts/runtime/claude-home/hooks/repo-counts-refresh.sh
+++ b/scripts/runtime/claude-home/hooks/repo-counts-refresh.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Fetch open issue/PR counts for a repo and cache them for the status line.
+
+set -u
+
+CWD="${1:-$(pwd)}"
+[[ -d "$CWD" ]] || exit 0
+
+REPO_DIR=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || true)
+[[ -n "$REPO_DIR" ]] || exit 0
+
+hash_path() {
+    if command -v md5sum >/dev/null 2>&1; then
+        printf '%s' "$1" | md5sum | awk '{print $1}'
+    elif command -v md5 >/dev/null 2>&1; then
+        printf '%s' "$1" | md5 -q
+    else
+        printf '%s' "$1" | cksum | awk '{print $1}'
+    fi
+}
+
+run_with_timeout() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 8 "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout 8 "$@"
+    else
+        "$@"
+    fi
+}
+
+CACHE_DIR="$HOME/.claude/cache/repo-status"
+mkdir -p "$CACHE_DIR" 2>/dev/null || exit 0
+
+HASH=$(hash_path "$REPO_DIR")
+CACHE="$CACHE_DIR/${HASH}.txt"
+LOCK="${CACHE}.lock"
+
+ISSUES=""
+PRS=""
+
+write_cache() {
+    {
+        printf 'repo=%s\n' "$REPO_DIR"
+        printf 'issues=%s\n' "$ISSUES"
+        printf 'prs=%s\n' "$PRS"
+        printf 'ts=%s\n' "$(date +%s)"
+    } > "$CACHE"
+}
+
+mkdir "$LOCK" 2>/dev/null || exit 0
+cleanup() {
+    write_cache
+    rmdir "$LOCK" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+git -C "$REPO_DIR" remote get-url origin >/dev/null 2>&1 || exit 0
+command -v gh >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+gh auth status >/dev/null 2>&1 || exit 0
+
+ISSUES=$(cd "$REPO_DIR" && run_with_timeout gh issue list --state open --limit 200 \
+    --json number 2>/dev/null | jq 'length' 2>/dev/null || echo "")
+PRS=$(cd "$REPO_DIR" && run_with_timeout gh pr list --state open --limit 200 \
+    --json number 2>/dev/null | jq 'length' 2>/dev/null || echo "")

--- a/scripts/runtime/claude-home/hooks/session-git-context.sh
+++ b/scripts/runtime/claude-home/hooks/session-git-context.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SessionStart hook: warm the status line repo-count cache without blocking.
+
+set -u
+
+cat >/dev/null
+
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+git remote get-url origin >/dev/null 2>&1 || exit 0
+
+( nohup bash "$HOME/.claude/hooks/repo-counts-refresh.sh" "$(pwd)" \
+    >/dev/null 2>&1 </dev/null & ) >/dev/null 2>&1
+
+exit 0

--- a/scripts/runtime/statusline-command.sh
+++ b/scripts/runtime/statusline-command.sh
@@ -11,7 +11,18 @@ input=$(cat)
 remaining=$(echo "$input" | jq -r '.context_window.remaining_percentage // empty')
 ctx_size=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
 model_id=$(echo "$input" | jq -r '.model.id // ""')
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
 effort=$(jq -r '.effortLevel // "normal"' ~/.claude/settings.json 2>/dev/null || echo "normal")
+
+hash_path() {
+    if command -v md5sum >/dev/null 2>&1; then
+        printf '%s' "$1" | md5sum | awk '{print $1}'
+    elif command -v md5 >/dev/null 2>&1; then
+        printf '%s' "$1" | md5 -q
+    else
+        printf '%s' "$1" | cksum | awk '{print $1}'
+    fi
+}
 
 # ANSI color codes
 RED=$'\033[0;31m'
@@ -50,4 +61,43 @@ else
     ctx="${CYAN}–${RESET}"
 fi
 
-printf "${CYAN}%s${RESET}  %s  ${CYAN}%s${RESET}\n" "$model" "$ctx" "$effort"
+# Git branch + repo counts (issues/PRs) are read from cache. If the cache is
+# stale, refresh it asynchronously so the status line itself stays fast.
+branch_state=""
+repo_state=""
+if [ -n "$cwd" ] && command -v git >/dev/null 2>&1; then
+    repo_dir=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+    if [ -n "$repo_dir" ]; then
+        branch=$(git -C "$repo_dir" symbolic-ref --short HEAD 2>/dev/null \
+            || git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null \
+            || true)
+        if [ -n "$branch" ]; then
+            branch_state="  ${CYAN}${branch}${RESET}"
+        fi
+
+        hash=$(hash_path "$repo_dir")
+        cache="$HOME/.claude/cache/repo-status/${hash}.txt"
+        now=$(date +%s)
+        ts=0
+        if [ -f "$cache" ]; then
+            ts=$(awk -F= '/^ts=/{print $2}' "$cache" 2>/dev/null)
+            issues=$(awk -F= '/^issues=/{print $2}' "$cache" 2>/dev/null)
+            prs=$(awk -F= '/^prs=/{print $2}' "$cache" 2>/dev/null)
+            if [ -n "${issues:-}" ] || [ -n "${prs:-}" ]; then
+                repo_state="  ${YELLOW}${issues:-?}i${RESET}/${CYAN}${prs:-?}p${RESET}"
+            fi
+        fi
+
+        case "${ts:-}" in
+            ''|*[!0-9]*) ts=0 ;;
+        esac
+        age=$(( now - ts ))
+        refresh_script="$HOME/.claude/hooks/repo-counts-refresh.sh"
+        if [ "$age" -gt 300 ] && [ -x "$refresh_script" ]; then
+            ( nohup bash "$refresh_script" "$repo_dir" \
+                >/dev/null 2>&1 </dev/null & ) >/dev/null 2>&1
+        fi
+    fi
+fi
+
+printf "${CYAN}%s${RESET}  %s  ${CYAN}%s${RESET}%s%s\n" "$model" "$ctx" "$effort" "$branch_state" "$repo_state"

--- a/scripts/runtime/sync-claude-personalization.sh
+++ b/scripts/runtime/sync-claude-personalization.sh
@@ -24,19 +24,21 @@ sync_file() {
     chmod "$mode" "$dest"
 }
 
-if [[ -d "$SOURCE_HOME/commands" ]]; then
-    while IFS= read -r -d '' src; do
-        rel="${src#"$SOURCE_HOME/"}"
-        sync_file "$src" "$CLAUDE_HOME/$rel" 644
-    done < <(find "$SOURCE_HOME/commands" -type f -print0)
-fi
+sync_tree() {
+    local subdir="$1"
+    local mode="$2"
+    local src rel
 
-if [[ -d "$SOURCE_HOME/skills" ]]; then
+    [[ -d "$SOURCE_HOME/$subdir" ]] || return 0
     while IFS= read -r -d '' src; do
         rel="${src#"$SOURCE_HOME/"}"
-        sync_file "$src" "$CLAUDE_HOME/$rel" 644
-    done < <(find "$SOURCE_HOME/skills" -type f -print0)
-fi
+        sync_file "$src" "$CLAUDE_HOME/$rel" "$mode"
+    done < <(find "$SOURCE_HOME/$subdir" -type f -print0)
+}
+
+sync_tree commands 644
+sync_tree skills 644
+sync_tree hooks 755
 
 if [[ "$CHANGED" -eq 1 ]]; then
     echo "updated"

--- a/tests/test-statusline.sh
+++ b/tests/test-statusline.sh
@@ -14,10 +14,29 @@ _run_statusline() {
 }
 
 _make_json() {
-    local pct="$1" size="${2:-200000}" model="${3:-claude-opus-4-6}"
-    cat <<JSON
-{"context_window":{"remaining_percentage":$pct,"context_window_size":$size},"model":{"id":"$model"}}
-JSON
+    local pct="$1" size="${2:-200000}" model="${3:-claude-opus-4-6}" cwd="${4:-}"
+    jq -n \
+        --argjson pct "$pct" \
+        --argjson size "$size" \
+        --arg model "$model" \
+        --arg cwd "$cwd" \
+        '{
+            context_window: {
+                remaining_percentage: $pct,
+                context_window_size: $size
+            },
+            model: {id: $model}
+        } + (if $cwd == "" then {} else {workspace: {current_dir: $cwd}} end)'
+}
+
+_hash_path() {
+    if command -v md5sum >/dev/null 2>&1; then
+        printf '%s' "$1" | md5sum | awk '{print $1}'
+    elif command -v md5 >/dev/null 2>&1; then
+        printf '%s' "$1" | md5 -q
+    else
+        printf '%s' "$1" | cksum | awk '{print $1}'
+    fi
 }
 
 test_parses_model_id() {
@@ -61,6 +80,28 @@ test_reads_effort_from_settings() {
     local output
     output=$(_run_statusline "$(_make_json 50)")
     assert_contains "$output" "low"
+}
+
+test_shows_git_branch_and_cached_repo_counts() {
+    local repo branch hash cache_dir output
+    repo=$(create_test_repo statusline-repo)
+    repo=$(git -C "$repo" rev-parse --show-toplevel)
+    branch=$(git -C "$repo" branch --show-current)
+    hash=$(_hash_path "$repo")
+    cache_dir="$HOME/.claude/cache/repo-status"
+    mkdir -p "$cache_dir"
+    {
+        printf 'repo=%s\n' "$repo"
+        printf 'issues=3\n'
+        printf 'prs=2\n'
+        printf 'ts=%s\n' "$(date +%s)"
+    } > "$cache_dir/${hash}.txt"
+
+    output=$(_run_statusline "$(_make_json 50 200000 "claude-opus-4-6" "$repo")")
+
+    assert_contains "$output" "$branch"
+    assert_contains "$output" "3i"
+    assert_contains "$output" "2p"
 }
 
 test_handles_empty_input() {

--- a/tests/test-sync-claude-personalization.sh
+++ b/tests/test-sync-claude-personalization.sh
@@ -14,7 +14,11 @@ test_syncs_user_scope_schedule_command() {
     assert_file_exists "$HOME/.claude/commands/schedule.md"
     assert_file_exists "$HOME/.claude/commands/host-schedule.md"
     assert_file_exists "$HOME/.claude/skills/host-schedule/SKILL.md"
+    assert_file_exists "$HOME/.claude/hooks/repo-counts-refresh.sh"
+    assert_file_exists "$HOME/.claude/hooks/session-git-context.sh"
     assert_contains "$(cat "$HOME/.claude/commands/schedule.md")" "aoc-schedule.sh"
     assert_contains "$(cat "$HOME/.claude/commands/host-schedule.md")" "aoc-schedule.sh"
     assert_contains "$(cat "$HOME/.claude/skills/host-schedule/SKILL.md")" "aoc-schedule.sh"
+    [[ -x "$HOME/.claude/hooks/repo-counts-refresh.sh" ]] || _fail "repo-counts-refresh.sh should be executable"
+    [[ -x "$HOME/.claude/hooks/session-git-context.sh" ]] || _fail "session-git-context.sh should be executable"
 }


### PR DESCRIPTION
## Summary

- Port the Claude status line customization from the cc host so it shows the current git branch plus cached open issue and PR counts.
- Add repo-managed Claude hook scripts that refresh the issue/PR count cache without blocking the status line.
- Extend Claude personalization sync and defaults so the hooks are installed for host/container setups.

## Validation

- `bash -n scripts/runtime/statusline-command.sh scripts/runtime/sync-claude-personalization.sh scripts/runtime/claude-home/hooks/repo-counts-refresh.sh scripts/runtime/claude-home/hooks/session-git-context.sh scripts/deploy/install.sh scripts/portable/entrypoint.sh`
- `bash tests/run.sh tests/test-statusline.sh tests/test-sync-claude-personalization.sh`
- `bash tests/run.sh tests/test-statusline.sh tests/test-sync-claude-personalization.sh tests/test-start-claude.sh tests/test-sync-codex-personalization.sh`
