### PR TITLE
[codex] Limit portable workspace sessions

### DIFF
--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -92,6 +92,90 @@ toggle_code_agent() {
     echo ""
 }
 
+all_code_agent_session_pattern() {
+    echo '^(claude|codex)-'
+}
+
+cgroup_memory_limit_mb() {
+    local path limit
+    for path in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+        [[ -r "$path" ]] || continue
+        limit=$(cat "$path" 2>/dev/null || true)
+        [[ "$limit" =~ ^[0-9]+$ ]] || continue
+        # Treat huge cgroup v1 sentinel values as unlimited.
+        [[ "$limit" -gt 0 && "$limit" -lt 9000000000000000000 ]] || continue
+        echo $((limit / 1024 / 1024))
+        return 0
+    done
+    return 1
+}
+
+total_memory_mb() {
+    if cgroup_memory_limit_mb; then
+        return
+    fi
+
+    if [[ -f /proc/meminfo ]]; then
+        awk '/MemTotal/ {printf "%.0f\n", $2/1024}' /proc/meminfo
+    elif command -v sysctl &>/dev/null; then
+        sysctl -n hw.memsize 2>/dev/null | awk '{printf "%.0f\n", $1/1024/1024}'
+    else
+        echo 4096
+    fi
+}
+
+count_sessions() {
+    tmux list-sessions -F '#{session_name}' 2>/dev/null \
+        | grep -Ec "$(all_code_agent_session_pattern)" || true
+}
+
+get_max_sessions() {
+    if [[ -n "${MAX_SESSIONS:-}" ]]; then
+        echo "$MAX_SESSIONS"
+        return
+    fi
+
+    local total_mem_mb cpus mem_based max
+    total_mem_mb=$(total_memory_mb)
+    cpus=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+    mem_based=$(( (total_mem_mb - 512) / 650 ))
+    [[ $mem_based -lt 1 ]] && mem_based=1
+
+    max=$(( mem_based < cpus ? mem_based : cpus ))
+    [[ $max -lt 1 ]] && max=1
+    echo "$max"
+}
+
+tmux_detach_hint() {
+    local prefix pretty
+    prefix=$(tmux show-option -gv prefix 2>/dev/null || echo "C-b")
+    pretty=$(echo "$prefix" | sed 's/C-/Ctrl-/')
+    echo "${pretty} d"
+}
+
+check_session_limit() {
+    local session_name="$1"
+    if tmux has-session -t "$session_name" 2>/dev/null; then
+        return 0
+    fi
+
+    local current max
+    current=$(count_sessions)
+    max=$(get_max_sessions)
+    if [[ $current -ge $max ]]; then
+        echo ""
+        echo "  Session limit reached ($current/$max)."
+        echo "  Each coding session uses ~650 MB — more sessions risk OOM."
+        echo ""
+        echo "  Options:"
+        echo "    - Re-attach to an existing session (select it from the menu)"
+        echo "    - Exit a running session ($(tmux_detach_hint) to detach, then /exit inside it)"
+        echo ""
+        return 1
+    fi
+    return 0
+}
+
 claude_authenticated() {
     [[ -n "${ANTHROPIC_API_KEY:-}" ]] && return 0
     [[ -d "$HOME/.claude" ]] \
@@ -257,6 +341,10 @@ launch() {
     # Create unique tmux session name
     session_name="${CODE_AGENT}-$(basename "$selected" | tr './:' '-')"
 
+    if ! check_session_limit "$session_name"; then
+        return 1
+    fi
+
     exec tmux new-session -A -s "$session_name" \
         "bash -lc 'exec bash \"$RUNNER\" --agent \"$CODE_AGENT\" --cwd \"$selected\"'"
 }
@@ -265,11 +353,16 @@ launch() {
 
 launch_manager() {
     local dir="$1"
+    local session_name="claude-manager"
+
+    if ! check_session_limit "$session_name"; then
+        return 1
+    fi
 
     echo "  -> workspace manager"
     echo ""
 
-    exec tmux new-session -A -s "claude-manager" \
+    exec tmux new-session -A -s "$session_name" \
         "bash -lc 'exec bash \"$RUNNER\" --agent claude --cwd \"$dir\" --prompt-file \"$MANAGER_PROMPT\" --message \"Greet me and show what you can help with.\"'"
 }
 

--- a/scripts/runtime/install-macmini-services.sh
+++ b/scripts/runtime/install-macmini-services.sh
@@ -4,6 +4,24 @@
 set -euo pipefail
 
 REPO="${AOC_REPO:-$HOME/always-on-claude}"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+
+disable_legacy_agent() {
+    local label="$1"
+    local plist="$LAUNCH_AGENTS_DIR/$label.plist"
+    local disabled="$plist.disabled"
+
+    [[ -f "$plist" ]] || return 0
+
+    launchctl bootout "gui/$(id -u)/$label" >/dev/null 2>&1 || \
+        launchctl unload "$plist" >/dev/null 2>&1 || true
+    mv "$plist" "$disabled"
+    printf '  OK: Disabled legacy LaunchAgent %s\n' "$label"
+}
+
+printf '\n=== Legacy Mac launch agents ===\n'
+disable_legacy_agent "com.always-on-claude.container"
+disable_legacy_agent "com.always-on-claude.update"
 
 bash "$REPO/scripts/runtime/install-macmini-host-tools.sh"
 bash "$REPO/scripts/runtime/install-macmini-schedule-bridge.sh"

--- a/tests/test-start-claude-portable.sh
+++ b/tests/test-start-claude-portable.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Tests for scripts/portable/start-claude-portable.sh
+
+PORTABLE_SCRIPT="$REPO_ROOT/scripts/portable/start-claude-portable.sh"
+
+_source_functions() {
+    eval "$(sed -n '/^all_code_agent_session_pattern()/,/^}/p' "$PORTABLE_SCRIPT")"
+    eval "$(sed -n '/^count_sessions()/,/^}/p' "$PORTABLE_SCRIPT")"
+    eval "$(sed -n '/^get_max_sessions()/,/^}/p' "$PORTABLE_SCRIPT")"
+    eval "$(sed -n '/^tmux_detach_hint()/,/^}/p' "$PORTABLE_SCRIPT")"
+    eval "$(sed -n '/^check_session_limit()/,/^}/p' "$PORTABLE_SCRIPT")"
+}
+
+setup() {
+    _source_functions
+    unset MAX_SESSIONS
+}
+
+test_max_sessions_env_override() {
+    MAX_SESSIONS=2
+    assert_eq "2" "$(get_max_sessions)"
+}
+
+test_count_sessions_counts_only_code_agents() {
+    cat > "$TEST_DIR/bin/tmux" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "list-sessions" ]]; then
+    echo "claude-app"
+    echo "codex-api"
+    echo "shell-local"
+fi
+MOCK
+    chmod +x "$TEST_DIR/bin/tmux"
+
+    assert_eq "2" "$(count_sessions)"
+}
+
+test_check_session_limit_allows_reattach() {
+    cat > "$TEST_DIR/bin/tmux" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "has-session" ]]; then
+    exit 0
+fi
+if [[ "$1" == "list-sessions" ]]; then
+    echo "claude-existing"
+fi
+MOCK
+    chmod +x "$TEST_DIR/bin/tmux"
+
+    MAX_SESSIONS=1
+    check_session_limit "claude-existing"
+}
+
+test_check_session_limit_blocks_new_session_at_limit() {
+    cat > "$TEST_DIR/bin/tmux" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "has-session" ]]; then
+    exit 1
+fi
+if [[ "$1" == "list-sessions" ]]; then
+    echo "claude-existing"
+fi
+if [[ "$1" == "show-option" ]]; then
+    echo "C-b"
+fi
+MOCK
+    chmod +x "$TEST_DIR/bin/tmux"
+
+    MAX_SESSIONS=1
+    local output exit_code=0
+    output=$(check_session_limit "claude-new" 2>&1) || exit_code=$?
+
+    assert_eq "1" "$exit_code"
+    assert_contains "$output" "Session limit reached (1/1)"
+    assert_contains "$output" "Ctrl-b d"
+}


### PR DESCRIPTION
## Summary

- Add the same parallel coding-session limit to the portable/container workspace menu used by Mac mini.
- Use cgroup memory limits when available so Mac mini Docker memory limits are respected.
- Disable legacy macOS LaunchAgents that still point at the old `~/dev-env` checkout.

## Validation

- `bash -n scripts/portable/start-claude-portable.sh scripts/runtime/install-macmini-services.sh tests/test-start-claude-portable.sh`
- `bash tests/run.sh tests/test-start-claude-portable.sh`
- `bash tests/run.sh tests/test-start-claude-portable.sh tests/test-start-claude.sh`
