### PR TITLE
[codex] Raise Mac mini Docker resources

### DIFF
--- a/docker-compose.macmini.yml
+++ b/docker-compose.macmini.yml
@@ -76,6 +76,7 @@ services:
         exec sleep infinity
       '
 
-    mem_limit: 3g
-    memswap_limit: 4g
+    mem_limit: 8g
+    memswap_limit: 8g
+    cpus: 4.0
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Raise the Mac mini Docker container memory cap to 8g.
- Set `memswap_limit` to 8g so total container memory remains capped at the requested 8g.
- Add a 4 CPU Compose limit for the Mac mini target.

## Validation

- `docker compose -f docker-compose.macmini.yml config`
- `bash tests/run.sh tests/test-start-claude-portable.sh`

## Runtime note

This changes the persisted Compose config. Applying it to the running Mac mini container requires recreating `claude-dev`; I did not do that while an attached tmux session was active.
