### PR TITLE
[codex] Add compact portable menu

### DIFF
--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -4,8 +4,8 @@
 # Unlike the host-mode start-claude.sh, this runs INSIDE the container.
 # No docker exec — launches the preferred coding assistant directly in tmux.
 #
-# Layer 1: Pick a repo (or manage workspaces)
-# Layer 2: Pick a branch/worktree within that repo (skipped if no worktrees)
+# Presents a compact flat menu with repos, worktrees, active sessions, and a
+# smart default.
 #
 # Called automatically from ssh-login-portable.sh on login.
 
@@ -19,7 +19,7 @@ if [[ -f "$CONFIG_ROOT/scripts/deploy/load-config.sh" ]]; then
 fi
 
 DEV_ENV="${DEV_ENV:-$CONFIG_ROOT}"
-WORKTREE_HELPER="$DEV_ENV/scripts/runtime/worktree-helper.sh"
+: "${PROJECTS_DIR:=$HOME/projects}"
 MANAGER_PROMPT="$DEV_ENV/scripts/runtime/manager-prompt.txt"
 RUNNER="$DEV_ENV/scripts/runtime/run-code-agent.sh"
 
@@ -94,6 +94,17 @@ toggle_code_agent() {
 
 all_code_agent_session_pattern() {
     echo '^(claude|codex)-'
+}
+
+all_menu_session_pattern() {
+    echo '^((claude|codex)-|shell-)'
+}
+
+code_agent_session_name() {
+    local path="$1"
+    local agent
+    agent=$(normalize_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
+    echo "${agent}-$(basename "$path" | tr './:' '-')"
 }
 
 cgroup_memory_limit_mb() {
@@ -235,121 +246,249 @@ first_run_check() {
     fi
 }
 
-# --- Discover repos and worktrees ---
+# --- Repo and worktree discovery -------------------------------------------
 
-discover() {
+normalize_discovered_path() {
+    local path="$1"
+    if [[ "$path" == /private/* && -e "${path#/private}" ]]; then
+        echo "${path#/private}"
+    else
+        echo "$path"
+    fi
+}
+
+discover_entries() {
     entries=()
-    while IFS= read -r line; do
-        [[ -n "$line" ]] && entries+=("$line")
-    done < <(bash "$WORKTREE_HELPER" list-repos 2>/dev/null | sort)
+    local repo_dirs=()
 
-    repos=()
-    repo_paths=()
-    for entry in "${entries[@]}"; do
-        IFS='|' read -r kind path branch <<< "$entry"
-        if [[ "$kind" == "REPO" ]]; then
-            repos+=("$path|$branch")
-            repo_paths+=("$path")
+    if command -v mapfile >/dev/null 2>&1; then
+        mapfile -t repo_dirs < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
+    else
+        local repo_dir
+        while IFS= read -r repo_dir; do
+            [[ -n "$repo_dir" ]] && repo_dirs+=("$repo_dir")
+        done < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
+    fi
+
+    [[ ${#repo_dirs[@]} -eq 0 ]] && return
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    for i in "${!repo_dirs[@]}"; do
+        local dir
+        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
+        (
+            branch=$(git -C "$dir" branch --show-current 2>/dev/null || echo "unknown")
+            echo "$branch" > "$tmpdir/${i}.branch"
+            git -C "$dir" worktree list --porcelain 2>/dev/null > "$tmpdir/${i}.worktrees" || true
+        ) &
+    done
+    wait
+
+    for i in "${!repo_dirs[@]}"; do
+        local dir
+        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
+        local branch repo_name
+        branch=$(cat "$tmpdir/${i}.branch")
+        repo_name=$(basename "$dir")
+
+        entries+=("${repo_name}|${branch}|${dir}|none|0")
+
+        local wt_path="" wt_branch=""
+        while IFS= read -r line; do
+            if [[ "$line" == "worktree "* ]]; then
+                wt_path=$(normalize_discovered_path "${line#worktree }")
+                wt_branch=""
+            elif [[ "$line" == "branch "* ]]; then
+                wt_branch="${line#branch refs/heads/}"
+            elif [[ -z "$line" ]]; then
+                if [[ "$wt_path" != "$dir" && -n "$wt_branch" ]]; then
+                    entries+=("${repo_name}|${wt_branch}|${wt_path}|none|0")
+                fi
+                wt_path=""
+                wt_branch=""
+            fi
+        done < <(cat "$tmpdir/${i}.worktrees"; echo)
+    done
+
+    rm -rf "$tmpdir"
+}
+
+# --- Session matching --------------------------------------------------------
+
+get_sessions() {
+    session_names=()
+    session_states=()
+    session_activities=()
+
+    local line
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        local name attached activity
+        read -r name attached activity <<< "$line"
+
+        [[ "$name" =~ $(all_menu_session_pattern) ]] || continue
+
+        session_names+=("$name")
+        if [[ "$attached" -gt 0 ]]; then
+            session_states+=("attached")
+        else
+            session_states+=("idle")
+        fi
+        session_activities+=("$activity")
+    done < <(tmux list-sessions -F '#{session_name} #{session_attached} #{session_activity}' 2>/dev/null || true)
+}
+
+match_sessions() {
+    orphaned_sessions=()
+
+    for si in "${!session_names[@]}"; do
+        local sname="${session_names[$si]}"
+        local sstate="${session_states[$si]}"
+        local sactivity="${session_activities[$si]}"
+        local found=false
+
+        for ei in "${!entries[@]}"; do
+            IFS='|' read -r repo_name branch path _state _activity <<< "${entries[$ei]}"
+            local expected_session
+            expected_session=$(code_agent_session_name "$path")
+
+            if [[ "$sname" == "$expected_session" ]]; then
+                entries[$ei]="${repo_name}|${branch}|${path}|${sstate}|${sactivity}"
+                found=true
+                break
+            fi
+        done
+
+        if [[ "$found" == false ]]; then
+            orphaned_sessions+=("${sname}|${sstate}|${sactivity}")
         fi
     done
 }
 
-# --- Get worktrees for a specific repo ---
+compute_default() {
+    default_idx=0
 
-get_worktrees() {
-    local repo_path="$1"
-    worktrees=()
-    while IFS= read -r line; do
-        [[ -n "$line" ]] && worktrees+=("$line")
-    done < <(bash "$WORKTREE_HELPER" list-worktrees "$repo_path" 2>/dev/null)
+    [[ ${#entries[@]} -eq 0 ]] && return
+
+    local best_idx=-1
+    local best_activity=0
+
+    for i in "${!entries[@]}"; do
+        IFS='|' read -r _ _ _ state activity <<< "${entries[$i]}"
+        if [[ "$state" == "idle" && "$activity" -gt "$best_activity" ]]; then
+            best_activity="$activity"
+            best_idx=$i
+        fi
+    done
+
+    if [[ $best_idx -ge 0 ]]; then
+        default_idx=$best_idx
+    fi
 }
 
-# --- Layer 1: Pick a repo ---
+# --- Compact menu rendering --------------------------------------------------
 
-show_repos() {
+show_menu() {
+    local prev_repo=""
+    local idx=1
     local next_agent
     next_agent=$(next_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
 
-    # Collect active code-agent and shell tmux sessions
-    # Note: all_sessions is intentionally global — read by reattach_session()
-    all_sessions=()
-    while IFS= read -r line; do
-        [[ -n "$line" ]] && all_sessions+=("$line")
-    done < <(tmux list-sessions -F '#{session_name} #{?session_attached,(attached),(idle)}' 2>/dev/null \
-        | grep -E '^((claude|codex)-|shell-)' || true)
+    echo ""
 
-    if [[ ${#all_sessions[@]} -gt 0 ]]; then
+    if [[ ${#entries[@]} -eq 0 ]]; then
+        echo "  (no repos — press m to clone)"
+    else
+        for i in "${!entries[@]}"; do
+            IFS='|' read -r repo_name branch path state activity <<< "${entries[$i]}"
+
+            if [[ "$repo_name" != "$prev_repo" ]]; then
+                [[ -n "$prev_repo" ]] && echo ""
+                echo "  ${repo_name}"
+                prev_repo="$repo_name"
+            fi
+
+            local marker=""
+            if [[ "$state" == "idle" ]]; then
+                marker="  <- active (idle)"
+            elif [[ "$state" == "attached" ]]; then
+                marker="  <- active (attached)"
+            fi
+
+            echo "  [${idx}] ${branch}${marker}"
+            ((idx++))
+        done
+    fi
+
+    if [[ ${#orphaned_sessions[@]} -gt 0 ]]; then
         echo ""
-        echo "  === Active sessions ==="
-        local ai=1
-        for s in "${all_sessions[@]}"; do
-            echo "  [a${ai}] $s"
-            ((ai++))
+        echo "  sessions"
+        for os in "${orphaned_sessions[@]}"; do
+            IFS='|' read -r sname sstate _ <<< "$os"
+            local omarker=""
+            [[ "$sstate" == "attached" ]] && omarker="  <- active (attached)"
+            [[ "$sstate" == "idle" ]] && omarker="  <- active (idle)"
+            echo "  [${idx}] ${sname}${omarker}"
+            ((idx++))
         done
     fi
 
     echo ""
-    echo "  === Repositories ==="
-    local i=1
-    for item in "${repos[@]+"${repos[@]}"}"; do
-        IFS='|' read -r path branch <<< "$item"
-        local short_path="${path#"$HOME"/}"
-        echo "  [$i] ${short_path} (${branch})"
-        ((i++))
-    done
-
-    if [[ ${#repos[@]} -eq 0 ]]; then
-        echo "  (no repos found — press [m] to clone your first repo)"
+    if [[ ${#entries[@]} -eq 0 ]]; then
+        echo "  Enter=m  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage  h=shell"
+    else
+        local default_display=$(( default_idx + 1 ))
+        echo "  Enter=${default_display}  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage  h=shell"
     fi
-
-    echo "  Default agent: $CODE_AGENT"
-    echo "  [t] Toggle default -> $next_agent"
-    echo "  [m] Manage workspaces"
-    echo "  [h] Shell"
     echo ""
 }
 
-# --- Layer 2: Pick a branch/worktree within a repo ---
+# --- Entry selection: reattach or launch -------------------------------------
 
-show_branches() {
-    local repo_path="$1" repo_branch="$2"
-    local short_path="${repo_path#"$HOME"/}"
+select_entry() {
+    local idx="$1"
 
-    echo ""
-    echo "  === ${short_path} ==="
-    echo "  [1] ${repo_branch} (repo)"
+    if [[ $idx -lt ${#entries[@]} ]]; then
+        IFS='|' read -r _ _ path state _ <<< "${entries[$idx]}"
+        local session_name
+        session_name=$(code_agent_session_name "$path")
 
-    local i=2
-    for wt in "${worktrees[@]+"${worktrees[@]}"}"; do
-        IFS='|' read -r _wt_path wt_branch <<< "$wt"
-        echo "  [$i] ${wt_branch} (worktree)"
-        ((i++))
-    done
-
-    echo "  [b] <- Back"
-    echo ""
+        if [[ "$state" == "idle" || "$state" == "attached" ]]; then
+            echo "  -> $session_name"
+            echo ""
+            tmux attach-session -t "$session_name"
+        else
+            launch "$path" || return 1
+        fi
+    else
+        local oi=$(( idx - ${#entries[@]} ))
+        IFS='|' read -r sname _ _ <<< "${orphaned_sessions[$oi]}"
+        echo "  -> $sname"
+        echo ""
+        tmux attach-session -t "$sname"
+    fi
 }
 
-# --- Launch the preferred code agent directly in tmux (no docker exec) ---
+# --- Launch the preferred code agent directly in tmux ------------------------
 
 launch() {
     local selected="$1"
-
-    echo "  -> $selected"
-    echo ""
-
-    # Create unique tmux session name
-    session_name="${CODE_AGENT}-$(basename "$selected" | tr './:' '-')"
+    local session_name
+    session_name=$(code_agent_session_name "$selected")
 
     if ! check_session_limit "$session_name"; then
         return 1
     fi
 
-    exec tmux new-session -A -s "$session_name" \
+    echo "  -> $session_name"
+    echo ""
+
+    tmux new-session -A -s "$session_name" \
         "bash -lc 'exec bash \"$RUNNER\" --agent \"$CODE_AGENT\" --cwd \"$selected\"'"
 }
 
-# --- Launch Claude for workspace management ---
+# --- Launch Claude for workspace management ----------------------------------
 
 launch_manager() {
     local dir="$1"
@@ -362,86 +501,52 @@ launch_manager() {
     echo "  -> workspace manager"
     echo ""
 
-    exec tmux new-session -A -s "$session_name" \
+    tmux new-session -A -s "$session_name" \
         "bash -lc 'exec bash \"$RUNNER\" --agent claude --cwd \"$dir\" --prompt-file \"$MANAGER_PROMPT\" --message \"Greet me and show what you can help with.\"'"
 }
 
-# --- Launch a shell in tmux ---
+# --- Launch a shell in tmux ---------------------------------------------------
+
 launch_shell() {
     echo "  -> shell"
     echo ""
-    exec tmux new-session -A -s "shell-local" "bash -l"
+    tmux new-session -A -s "shell-local" "bash -l"
 }
 
-# --- Reattach to an active session by index ---
-# Note: all_sessions is intentionally global — populated by show_repos(), read here
-reattach_session() {
-    local idx="$1"
-    if [[ $idx -ge 1 && $idx -le ${#all_sessions[@]} ]]; then
-        local session_line="${all_sessions[$((idx - 1))]}"
-        local session_name="${session_line%% *}"
-        echo "  -> reattach $session_name"
-        echo ""
-        exec tmux attach-session -t "$session_name"
-    fi
-    return 1
-}
-
-# --- Main ---
+# --- Main ---------------------------------------------------------------------
 
 first_run_check
-discover
 
-# Layer 1 loop
 while true; do
-    show_repos
+    discover_entries
+    get_sessions
+    match_sessions
+    compute_default
+    show_menu
 
     read -r -p "  > " choice || true
 
     if [[ "$choice" == "m" ]]; then
-        launch_manager "$DEV_ENV"
+        launch_manager "$DEV_ENV" || true
+        continue
     elif [[ "$choice" == "t" ]]; then
         toggle_code_agent
         continue
     elif [[ "$choice" == "h" ]]; then
         launch_shell
-    elif [[ "$choice" =~ ^a([0-9]+)$ ]]; then
-        reattach_session "${BASH_REMATCH[1]}" || continue
-    elif [[ "$choice" =~ ^[0-9]+$ && "$choice" -ge 1 && "$choice" -le "${#repos[@]}" ]]; then
-        IFS='|' read -r selected_path selected_branch <<< "${repos[$((choice - 1))]}"
-    elif [[ -z "$choice" ]]; then
-        # Default: first repo, or projects dir if none
-        if [[ ${#repos[@]} -gt 0 ]]; then
-            IFS='|' read -r selected_path selected_branch <<< "${repos[0]}"
-        else
-            launch "$HOME/projects"
-        fi
-    else
         continue
-    fi
-
-    # Check for worktrees
-    get_worktrees "$selected_path"
-
-    # If no worktrees, skip Layer 2 and launch directly
-    if [[ ${#worktrees[@]} -eq 0 ]]; then
-        launch "$selected_path"
-    fi
-
-    # Layer 2 loop
-    while true; do
-        show_branches "$selected_path" "$selected_branch"
-
-        read -r -p "  > " choice2 || true
-
-        if [[ "$choice2" == "b" ]]; then
-            break  # Back to Layer 1
-        elif [[ "$choice2" == "1" || -z "$choice2" ]]; then
-            # Main repo
-            launch "$selected_path"
-        elif [[ "$choice2" =~ ^[0-9]+$ && "$choice2" -ge 2 && "$choice2" -le $(( ${#worktrees[@]} + 1 )) ]]; then
-            IFS='|' read -r wt_selected _ <<< "${worktrees[$((choice2 - 2))]}"
-            launch "$wt_selected"
+    elif [[ -z "$choice" ]]; then
+        if [[ ${#entries[@]} -eq 0 ]]; then
+            launch_manager "$DEV_ENV" || true
+        else
+            select_entry "$default_idx" || true
         fi
-    done
+        continue
+    elif [[ "$choice" =~ ^[0-9]+$ ]]; then
+        idx=$(( choice - 1 ))
+        total=$(( ${#entries[@]} + ${#orphaned_sessions[@]} ))
+        if [[ $idx -ge 0 && $idx -lt $total ]]; then
+            select_entry "$idx" || true
+        fi
+    fi
 done


### PR DESCRIPTION
## Summary

- Replace the portable two-layer repo/worktree picker with a compact flat menu matching the host-mode startup menu behavior.
- Inline repo and worktree discovery for the portable menu, then match active tmux sessions back to menu entries.
- Preserve portable-specific behavior: launches run directly inside the container and the footer exposes `h=shell` rather than a separate container shell option.

## Impact

Mac mini portable sessions now get the same faster, denser startup menu shape as `cc`: grouped repos, inline active markers, smart Enter default, agent toggle, manager, and shell access.

## Validation

- `bash -n scripts/portable/start-claude-portable.sh`
- `bash -n scripts/portable/ssh-login-portable.sh`
- `bash -n scripts/runtime/aoc-menu-mac.sh`
- Deployed the script to the Mac mini host repo and verified syntax inside the running `claude-dev` container.
- Rendered the Mac mini container menu non-interactively and confirmed the compact footer: `Enter=1  agent=codex  t=toggle->claude  m=manage  h=shell`.

Note: `shellcheck` is not installed in this local environment, so it was not run.