### PR TITLE
Refactor macmini menu scripts

### DIFF
--- a/docker-compose.macmini.yml
+++ b/docker-compose.macmini.yml
@@ -73,6 +73,10 @@ services:
           cp ~/dev-env/scripts/runtime/tmux-status.sh ~/.tmux-status.sh;
           chmod +x ~/.tmux-status.sh;
         fi;
+        if [ -x ~/dev-env/scripts/runtime/upgrade-code-agents.sh ]; then
+          mkdir -p ~/.cache/aoc;
+          ~/dev-env/scripts/runtime/upgrade-code-agents.sh | tee ~/.cache/aoc/agent-upgrade.log || true;
+        fi;
         exec sleep infinity
       '
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -256,6 +256,16 @@ Runs as root, then drops privileges:
 | `OPENAI_API_KEY` | API key auth for Codex (alternative to `codex login`) |
 | `DEFAULT_CODE_AGENT` | Default assistant launched by the picker (`claude` or `codex`) |
 
+### Mac mini agent upgrades
+
+`docker-compose.macmini.yml` runs `scripts/runtime/upgrade-code-agents.sh` whenever the Mac mini container starts. The script runs as the non-root `dev` user:
+
+- Claude Code is updated with `claude update`.
+- Codex is installed/updated with npm into `~/.local`, avoiding root-owned global npm directories.
+- The latest upgrade log is written to `~/.cache/aoc/agent-upgrade.log` inside the container.
+
+Set `AOC_AUTO_UPGRADE_AGENTS=0` in the compose environment to disable this startup check.
+
 ## Tailscale
 
 Private SSH access without exposing ports to the internet.

--- a/scripts/lib/start-menu-common.sh
+++ b/scripts/lib/start-menu-common.sh
@@ -240,7 +240,7 @@ match_sessions() {
         local exists=false
         local pi
         for pi in "${!project_entries[@]}"; do
-            IFS='|' read -r project_name _main_branch _main_path _selected_branch _selected_path _selected_state _selected_activity <<< "${project_entries[$pi]}"
+            IFS='|' read -r project_name _main_branch _main_path _selected_branch _selected_path _ _selected_activity <<< "${project_entries[$pi]}"
             if [[ "$project_name" == "$repo_name" ]]; then
                 exists=true
                 break

--- a/scripts/lib/start-menu-common.sh
+++ b/scripts/lib/start-menu-common.sh
@@ -266,7 +266,7 @@ match_sessions() {
             if [[ "$sname" == "$expected_session" ]]; then
                 local pi
                 for pi in "${!project_entries[@]}"; do
-                    IFS='|' read -r project_name _main_branch _main_path _selected_branch _selected_path selected_state selected_activity <<< "${project_entries[$pi]}"
+                    IFS='|' read -r project_name _main_branch _main_path _selected_branch _selected_path _ selected_activity <<< "${project_entries[$pi]}"
                     [[ "$project_name" == "$repo_name" ]] || continue
                     if [[ "$sactivity" -gt "$selected_activity" ]]; then
                         project_entries[$pi]="${project_name}|${_main_branch}|${_main_path}|${branch}|${path}|${sstate}|${sactivity}"

--- a/scripts/lib/start-menu-common.sh
+++ b/scripts/lib/start-menu-common.sh
@@ -1,0 +1,456 @@
+#!/bin/bash
+
+normalize_code_agent() {
+    case "${1:-}" in
+        codex) echo "codex" ;;
+        claude|"") echo "claude" ;;
+        *) echo "claude" ;;
+    esac
+}
+
+next_code_agent() {
+    local agent
+    agent=$(normalize_code_agent "${1:-${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}}")
+    if [[ "$agent" == "codex" ]]; then
+        echo "claude"
+    else
+        echo "codex"
+    fi
+}
+
+persist_default_code_agent() {
+    local agent profile tmp
+    agent=$(normalize_code_agent "${1:-claude}")
+    profile="$HOME/.bash_profile"
+
+    touch "$profile"
+
+    tmp=$(mktemp)
+    awk -v agent="$agent" '
+        BEGIN {
+            updated = 0
+            comment = "# Default coding assistant for the workspace picker"
+            export_line = "export DEFAULT_CODE_AGENT=\"" agent "\""
+        }
+        /^export DEFAULT_CODE_AGENT=/ {
+            if (!updated) {
+                print export_line
+                updated = 1
+            }
+            next
+        }
+        { print }
+        END {
+            if (!updated) {
+                if (NR > 0) {
+                    print ""
+                }
+                print comment
+                print export_line
+            }
+        }
+    ' "$profile" > "$tmp"
+    cat "$tmp" > "$profile"
+    rm -f "$tmp"
+
+    DEFAULT_CODE_AGENT="$agent"
+    CODE_AGENT="$agent"
+    export DEFAULT_CODE_AGENT CODE_AGENT
+}
+
+toggle_code_agent() {
+    local next_agent
+    next_agent=$(next_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
+    persist_default_code_agent "$next_agent"
+    echo ""
+    echo "  Default agent set to: $CODE_AGENT"
+    echo ""
+}
+
+all_code_agent_session_pattern() {
+    echo '^(claude|codex)-'
+}
+
+menu_session_pattern() {
+    all_code_agent_session_pattern
+}
+
+code_agent_session_name() {
+    local path="$1"
+    local agent
+    agent=$(normalize_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
+    echo "${agent}-$(basename "$path" | tr './:' '-')"
+}
+
+total_memory_mb() {
+    if [[ -f /proc/meminfo ]]; then
+        awk '/MemTotal/ {printf "%.0f\n", $2/1024}' /proc/meminfo
+    elif command -v sysctl &>/dev/null; then
+        sysctl -n hw.memsize 2>/dev/null | awk '{printf "%.0f\n", $1/1024/1024}'
+    else
+        echo 4096
+    fi
+}
+
+count_sessions() {
+    tmux list-sessions -F '#{session_name}' 2>/dev/null \
+        | grep -Ec "$(all_code_agent_session_pattern)" || true
+}
+
+get_max_sessions() {
+    if [[ -n "${MAX_SESSIONS:-}" ]]; then
+        echo "$MAX_SESSIONS"
+        return
+    fi
+
+    local total_mem_mb cpus mem_based max
+    total_mem_mb=$(total_memory_mb)
+    cpus=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+    mem_based=$(( (total_mem_mb - 512) / 650 ))
+    [[ $mem_based -lt 1 ]] && mem_based=1
+
+    max=$(( mem_based < cpus ? mem_based : cpus ))
+    [[ $max -lt 1 ]] && max=1
+    echo "$max"
+}
+
+tmux_detach_hint() {
+    local prefix pretty
+    prefix=$(tmux show-option -gv prefix 2>/dev/null || echo "C-b")
+    pretty=$(echo "$prefix" | sed 's/C-/Ctrl-/')
+    echo "${pretty} d"
+}
+
+check_session_limit() {
+    local session_name="$1"
+    if tmux has-session -t "$session_name" 2>/dev/null; then
+        return 0
+    fi
+
+    local current max
+    current=$(count_sessions)
+    max=$(get_max_sessions)
+    if [[ $current -ge $max ]]; then
+        echo ""
+        echo "  Session limit reached ($current/$max)."
+        echo "  Each coding session uses ~650 MB — more sessions risk OOM."
+        echo ""
+        echo "  Options:"
+        echo "    - Re-attach to an existing session (select it from the menu)"
+        echo "    - Exit a running session ($(tmux_detach_hint) to detach, then /exit inside it)"
+        echo ""
+        return 1
+    fi
+    return 0
+}
+
+normalize_discovered_path() {
+    local path="$1"
+    if [[ "$path" == /private/* && -e "${path#/private}" ]]; then
+        echo "${path#/private}"
+    else
+        echo "$path"
+    fi
+}
+
+discover_entries() {
+    entries=()
+    local repo_dirs=()
+    if command -v mapfile >/dev/null 2>&1; then
+        mapfile -t repo_dirs < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
+    else
+        local repo_dir
+        while IFS= read -r repo_dir; do
+            [[ -n "$repo_dir" ]] && repo_dirs+=("$repo_dir")
+        done < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
+    fi
+
+    [[ ${#repo_dirs[@]} -eq 0 ]] && return
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    for i in "${!repo_dirs[@]}"; do
+        local dir
+        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
+        (
+            branch=$(git -C "$dir" branch --show-current 2>/dev/null || echo "unknown")
+            echo "$branch" > "$tmpdir/${i}.branch"
+            git -C "$dir" worktree list --porcelain 2>/dev/null > "$tmpdir/${i}.worktrees" || true
+        ) &
+    done
+    wait
+
+    for i in "${!repo_dirs[@]}"; do
+        local dir branch repo_name
+        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
+        branch=$(cat "$tmpdir/${i}.branch")
+        repo_name=$(basename "$dir")
+
+        entries+=("${repo_name}|${branch}|${dir}|none|0")
+
+        local wt_path="" wt_branch=""
+        while IFS= read -r line; do
+            if [[ "$line" == "worktree "* ]]; then
+                wt_path=$(normalize_discovered_path "${line#worktree }")
+                wt_branch=""
+            elif [[ "$line" == "branch "* ]]; then
+                wt_branch="${line#branch refs/heads/}"
+            elif [[ -z "$line" ]]; then
+                if [[ "$wt_path" != "$dir" && -n "$wt_branch" ]]; then
+                    entries+=("${repo_name}|${wt_branch}|${wt_path}|none|0")
+                fi
+                wt_path=""
+                wt_branch=""
+            fi
+        done < <(cat "$tmpdir/${i}.worktrees"; echo)
+    done
+
+    rm -rf "$tmpdir"
+}
+
+get_sessions() {
+    session_names=()
+    session_states=()
+    session_activities=()
+
+    local line
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        local name attached activity
+        read -r name attached activity <<< "$line"
+
+        [[ "$name" =~ $(menu_session_pattern) ]] || continue
+
+        session_names+=("$name")
+        if [[ "$attached" -gt 0 ]]; then
+            session_states+=("attached")
+        else
+            session_states+=("idle")
+        fi
+        session_activities+=("$activity")
+    done < <(tmux list-sessions -F '#{session_name} #{session_attached} #{session_activity}' 2>/dev/null || true)
+}
+
+match_sessions() {
+    project_entries=()
+    orphaned_sessions=()
+
+    for ei in "${!entries[@]}"; do
+        IFS='|' read -r repo_name branch path _state _activity <<< "${entries[$ei]}"
+        local exists=false
+        local pi
+        for pi in "${!project_entries[@]}"; do
+            IFS='|' read -r project_name _main_branch _main_path _selected_branch _selected_path _selected_state _selected_activity <<< "${project_entries[$pi]}"
+            if [[ "$project_name" == "$repo_name" ]]; then
+                exists=true
+                break
+            fi
+        done
+
+        if [[ "$exists" == false ]]; then
+            project_entries+=("${repo_name}|${branch}|${path}|${branch}|${path}|none|0")
+        fi
+    done
+
+    for si in "${!session_names[@]}"; do
+        local sname="${session_names[$si]}"
+        local sstate="${session_states[$si]}"
+        local sactivity="${session_activities[$si]}"
+        local found=false
+
+        for ei in "${!entries[@]}"; do
+            IFS='|' read -r repo_name branch path _state _activity <<< "${entries[$ei]}"
+            local expected_session
+            expected_session=$(code_agent_session_name "$path")
+
+            if [[ "$sname" == "$expected_session" ]]; then
+                local pi
+                for pi in "${!project_entries[@]}"; do
+                    IFS='|' read -r project_name _main_branch _main_path _selected_branch _selected_path selected_state selected_activity <<< "${project_entries[$pi]}"
+                    [[ "$project_name" == "$repo_name" ]] || continue
+                    if [[ "$sactivity" -gt "$selected_activity" ]]; then
+                        project_entries[$pi]="${project_name}|${_main_branch}|${_main_path}|${branch}|${path}|${sstate}|${sactivity}"
+                    fi
+                    break
+                done
+                found=true
+                break
+            fi
+        done
+
+        if [[ "$found" == false ]]; then
+            orphaned_sessions+=("${sname}|${sstate}|${sactivity}")
+        fi
+    done
+}
+
+compute_default() {
+    default_idx=0
+
+    [[ ${#project_entries[@]} -eq 0 ]] && return
+
+    local best_idx=-1
+    local best_activity=0
+
+    for i in "${!project_entries[@]}"; do
+        IFS='|' read -r _ _ _ _ _ state activity <<< "${project_entries[$i]}"
+        if [[ "$state" == "idle" && "$activity" -gt "$best_activity" ]]; then
+            best_activity="$activity"
+            best_idx=$i
+        fi
+    done
+
+    if [[ $best_idx -lt 0 ]]; then
+        for i in "${!project_entries[@]}"; do
+            IFS='|' read -r _ _ _ _ _ state activity <<< "${project_entries[$i]}"
+            if [[ "$state" == "attached" && "$activity" -gt "$best_activity" ]]; then
+                best_activity="$activity"
+                best_idx=$i
+            fi
+        done
+    fi
+
+    if [[ $best_idx -ge 0 ]]; then
+        default_idx=$best_idx
+    fi
+}
+
+menu_footer_actions() {
+    echo "${MENU_ACTIONS:-}"
+}
+
+show_menu() {
+    local idx=1
+    local next_agent footer_actions
+    next_agent=$(next_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
+    footer_actions=$(menu_footer_actions)
+
+    echo ""
+
+    if [[ ${#project_entries[@]} -eq 0 ]]; then
+        echo "  (no repos — press m to clone)"
+    else
+        for i in "${!project_entries[@]}"; do
+            IFS='|' read -r repo_name main_branch _main_path selected_branch _selected_path state _activity <<< "${project_entries[$i]}"
+            local marker=""
+            if [[ "$state" == "idle" ]]; then
+                marker="  active"
+            elif [[ "$state" == "attached" ]]; then
+                marker="  attached"
+            fi
+
+            if [[ "$state" == "none" ]]; then
+                selected_branch="$main_branch"
+            fi
+
+            echo "  [${idx}] ${repo_name}  ${selected_branch}${marker}"
+            ((idx++))
+        done
+    fi
+
+    if [[ ${#orphaned_sessions[@]} -gt 0 ]]; then
+        echo ""
+        echo "  sessions"
+        for os in "${orphaned_sessions[@]}"; do
+            IFS='|' read -r sname sstate _ <<< "$os"
+            local omarker=""
+            [[ "$sstate" == "attached" ]] && omarker="  attached"
+            [[ "$sstate" == "idle" ]] && omarker="  active"
+            echo "  [${idx}] ${sname}${omarker}"
+            ((idx++))
+        done
+    fi
+
+    echo ""
+    if [[ ${#project_entries[@]} -eq 0 ]]; then
+        echo "  Enter=m  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage${footer_actions:+  ${footer_actions}}"
+    else
+        local default_display=$(( default_idx + 1 ))
+        echo "  Enter=${default_display}  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage${footer_actions:+  ${footer_actions}}"
+    fi
+    echo ""
+}
+
+prepare_project_launch() {
+    :
+}
+
+prepare_manager_launch() {
+    :
+}
+
+select_entry() {
+    local idx="$1"
+
+    if [[ $idx -lt ${#project_entries[@]} ]]; then
+        IFS='|' read -r _ _main_branch main_path _selected_branch selected_path state _ <<< "${project_entries[$idx]}"
+        local launch_path="$main_path"
+        local session_name=""
+
+        if [[ "$state" == "idle" || "$state" == "attached" ]]; then
+            session_name=$(code_agent_session_name "$selected_path")
+        fi
+
+        if [[ "$state" == "idle" || "$state" == "attached" ]]; then
+            echo "  -> $session_name"
+            echo ""
+            tmux attach-session -t "$session_name"
+        else
+            prepare_project_launch || return 1
+            launch "$launch_path" || return 1
+        fi
+    else
+        local oi=$(( idx - ${#project_entries[@]} ))
+        IFS='|' read -r sname _ _ <<< "${orphaned_sessions[$oi]}"
+        echo "  -> $sname"
+        echo ""
+        tmux attach-session -t "$sname"
+    fi
+}
+
+handle_extra_choice() {
+    return 1
+}
+
+before_picker_loop() {
+    :
+}
+
+run_picker_loop() {
+    before_picker_loop
+
+    while true; do
+        discover_entries
+        get_sessions
+        match_sessions
+        compute_default
+        show_menu
+
+        read -r -p "  > " choice || true
+
+        if [[ "$choice" == "m" ]]; then
+            prepare_manager_launch || continue
+            launch_manager "$MANAGER_TARGET" || true
+            continue
+        elif [[ "$choice" == "t" ]]; then
+            toggle_code_agent
+            continue
+        elif handle_extra_choice "$choice"; then
+            continue
+        elif [[ -z "$choice" ]]; then
+            if [[ ${#project_entries[@]} -eq 0 ]]; then
+                prepare_manager_launch || continue
+                launch_manager "$MANAGER_TARGET" || true
+            else
+                select_entry "$default_idx" || true
+            fi
+            continue
+        elif [[ "$choice" =~ ^[0-9]+$ ]]; then
+            idx=$(( choice - 1 ))
+            total=$(( ${#project_entries[@]} + ${#orphaned_sessions[@]} ))
+            if [[ $idx -ge 0 && $idx -lt $total ]]; then
+                select_entry "$idx" || true
+            fi
+        fi
+    done
+}

--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -20,10 +20,13 @@ DEV_ENV="${DEV_ENV:-$CONFIG_ROOT}"
 : "${PROJECTS_DIR:=$HOME/projects}"
 MANAGER_PROMPT="$DEV_ENV/scripts/runtime/manager-prompt.txt"
 RUNNER="$DEV_ENV/scripts/runtime/run-code-agent.sh"
+# Shared picker config consumed by scripts/lib/start-menu-common.sh.
+# shellcheck disable=SC2034
 MANAGER_TARGET="$DEV_ENV"
+# shellcheck disable=SC2034
 MENU_ACTIONS="h=shell"
 
-# shellcheck disable=SC1091
+# shellcheck source=../lib/start-menu-common.sh
 source "$COMMON_LIB"
 
 CODE_AGENT=$(normalize_code_agent "${DEFAULT_CODE_AGENT:-claude}")

--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -4,14 +4,12 @@
 # Unlike the host-mode start-claude.sh, this runs INSIDE the container.
 # No docker exec — launches the preferred coding assistant directly in tmux.
 #
-# Presents a compact flat menu with repos, worktrees, active sessions, and a
-# smart default.
-#
 # Called automatically from ssh-login-portable.sh on login.
 
 set -euo pipefail
 
 CONFIG_ROOT="${DEV_ENV:-$HOME/dev-env}"
+COMMON_LIB="$CONFIG_ROOT/scripts/lib/start-menu-common.sh"
 
 if [[ -f "$CONFIG_ROOT/scripts/deploy/load-config.sh" ]]; then
     # shellcheck disable=SC1091
@@ -22,89 +20,20 @@ DEV_ENV="${DEV_ENV:-$CONFIG_ROOT}"
 : "${PROJECTS_DIR:=$HOME/projects}"
 MANAGER_PROMPT="$DEV_ENV/scripts/runtime/manager-prompt.txt"
 RUNNER="$DEV_ENV/scripts/runtime/run-code-agent.sh"
+MANAGER_TARGET="$DEV_ENV"
+MENU_ACTIONS="h=shell"
 
-normalize_code_agent() {
-    case "${1:-}" in
-        codex) echo "codex" ;;
-        claude|"") echo "claude" ;;
-        *) echo "claude" ;;
-    esac
-}
+# shellcheck disable=SC1091
+source "$COMMON_LIB"
 
 CODE_AGENT=$(normalize_code_agent "${DEFAULT_CODE_AGENT:-claude}")
-
-next_code_agent() {
-    local agent
-    agent=$(normalize_code_agent "${1:-${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}}")
-    if [[ "$agent" == "codex" ]]; then
-        echo "claude"
-    else
-        echo "codex"
-    fi
-}
-
-persist_default_code_agent() {
-    local agent profile tmp
-    agent=$(normalize_code_agent "${1:-claude}")
-    profile="$HOME/.bash_profile"
-
-    touch "$profile"
-
-    tmp=$(mktemp)
-    awk -v agent="$agent" '
-        BEGIN {
-            updated = 0
-            comment = "# Default coding assistant for the workspace picker"
-            export_line = "export DEFAULT_CODE_AGENT=\"" agent "\""
-        }
-        /^export DEFAULT_CODE_AGENT=/ {
-            if (!updated) {
-                print export_line
-                updated = 1
-            }
-            next
-        }
-        { print }
-        END {
-            if (!updated) {
-                if (NR > 0) {
-                    print ""
-                }
-                print comment
-                print export_line
-            }
-        }
-    ' "$profile" > "$tmp"
-    cat "$tmp" > "$profile"
-    rm -f "$tmp"
-
-    DEFAULT_CODE_AGENT="$agent"
-    CODE_AGENT="$agent"
-    export DEFAULT_CODE_AGENT CODE_AGENT
-}
-
-toggle_code_agent() {
-    local next_agent
-    next_agent=$(next_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
-    persist_default_code_agent "$next_agent"
-    echo ""
-    echo "  Default agent set to: $CODE_AGENT"
-    echo ""
-}
-
-all_code_agent_session_pattern() {
-    echo '^(claude|codex)-'
-}
 
 all_menu_session_pattern() {
     echo '^((claude|codex)-|shell-)'
 }
 
-code_agent_session_name() {
-    local path="$1"
-    local agent
-    agent=$(normalize_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
-    echo "${agent}-$(basename "$path" | tr './:' '-')"
+menu_session_pattern() {
+    all_menu_session_pattern
 }
 
 cgroup_memory_limit_mb() {
@@ -113,7 +42,6 @@ cgroup_memory_limit_mb() {
         [[ -r "$path" ]] || continue
         limit=$(cat "$path" 2>/dev/null || true)
         [[ "$limit" =~ ^[0-9]+$ ]] || continue
-        # Treat huge cgroup v1 sentinel values as unlimited.
         [[ "$limit" -gt 0 && "$limit" -lt 9000000000000000000 ]] || continue
         echo $((limit / 1024 / 1024))
         return 0
@@ -135,58 +63,6 @@ total_memory_mb() {
     fi
 }
 
-count_sessions() {
-    tmux list-sessions -F '#{session_name}' 2>/dev/null \
-        | grep -Ec "$(all_code_agent_session_pattern)" || true
-}
-
-get_max_sessions() {
-    if [[ -n "${MAX_SESSIONS:-}" ]]; then
-        echo "$MAX_SESSIONS"
-        return
-    fi
-
-    local total_mem_mb cpus mem_based max
-    total_mem_mb=$(total_memory_mb)
-    cpus=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
-    mem_based=$(( (total_mem_mb - 512) / 650 ))
-    [[ $mem_based -lt 1 ]] && mem_based=1
-
-    max=$(( mem_based < cpus ? mem_based : cpus ))
-    [[ $max -lt 1 ]] && max=1
-    echo "$max"
-}
-
-tmux_detach_hint() {
-    local prefix pretty
-    prefix=$(tmux show-option -gv prefix 2>/dev/null || echo "C-b")
-    pretty=$(echo "$prefix" | sed 's/C-/Ctrl-/')
-    echo "${pretty} d"
-}
-
-check_session_limit() {
-    local session_name="$1"
-    if tmux has-session -t "$session_name" 2>/dev/null; then
-        return 0
-    fi
-
-    local current max
-    current=$(count_sessions)
-    max=$(get_max_sessions)
-    if [[ $current -ge $max ]]; then
-        echo ""
-        echo "  Session limit reached ($current/$max)."
-        echo "  Each coding session uses ~650 MB — more sessions risk OOM."
-        echo ""
-        echo "  Options:"
-        echo "    - Re-attach to an existing session (select it from the menu)"
-        echo "    - Exit a running session ($(tmux_detach_hint) to detach, then /exit inside it)"
-        echo ""
-        return 1
-    fi
-    return 0
-}
-
 claude_authenticated() {
     [[ -n "${ANTHROPIC_API_KEY:-}" ]] && return 0
     [[ -d "$HOME/.claude" ]] \
@@ -198,8 +74,6 @@ codex_authenticated() {
     [[ -n "${OPENAI_API_KEY:-}" ]] && return 0
     command -v codex &>/dev/null && codex login status &>/dev/null
 }
-
-# --- First-run check: prompt for auth if not configured --------------------
 
 first_run_check() {
     local needs_setup=0
@@ -246,232 +120,6 @@ first_run_check() {
     fi
 }
 
-# --- Repo and worktree discovery -------------------------------------------
-
-normalize_discovered_path() {
-    local path="$1"
-    if [[ "$path" == /private/* && -e "${path#/private}" ]]; then
-        echo "${path#/private}"
-    else
-        echo "$path"
-    fi
-}
-
-discover_entries() {
-    entries=()
-    local repo_dirs=()
-
-    if command -v mapfile >/dev/null 2>&1; then
-        mapfile -t repo_dirs < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
-    else
-        local repo_dir
-        while IFS= read -r repo_dir; do
-            [[ -n "$repo_dir" ]] && repo_dirs+=("$repo_dir")
-        done < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
-    fi
-
-    [[ ${#repo_dirs[@]} -eq 0 ]] && return
-
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    for i in "${!repo_dirs[@]}"; do
-        local dir
-        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
-        (
-            branch=$(git -C "$dir" branch --show-current 2>/dev/null || echo "unknown")
-            echo "$branch" > "$tmpdir/${i}.branch"
-            git -C "$dir" worktree list --porcelain 2>/dev/null > "$tmpdir/${i}.worktrees" || true
-        ) &
-    done
-    wait
-
-    for i in "${!repo_dirs[@]}"; do
-        local dir
-        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
-        local branch repo_name
-        branch=$(cat "$tmpdir/${i}.branch")
-        repo_name=$(basename "$dir")
-
-        entries+=("${repo_name}|${branch}|${dir}|none|0")
-
-        local wt_path="" wt_branch=""
-        while IFS= read -r line; do
-            if [[ "$line" == "worktree "* ]]; then
-                wt_path=$(normalize_discovered_path "${line#worktree }")
-                wt_branch=""
-            elif [[ "$line" == "branch "* ]]; then
-                wt_branch="${line#branch refs/heads/}"
-            elif [[ -z "$line" ]]; then
-                if [[ "$wt_path" != "$dir" && -n "$wt_branch" ]]; then
-                    entries+=("${repo_name}|${wt_branch}|${wt_path}|none|0")
-                fi
-                wt_path=""
-                wt_branch=""
-            fi
-        done < <(cat "$tmpdir/${i}.worktrees"; echo)
-    done
-
-    rm -rf "$tmpdir"
-}
-
-# --- Session matching --------------------------------------------------------
-
-get_sessions() {
-    session_names=()
-    session_states=()
-    session_activities=()
-
-    local line
-    while IFS= read -r line; do
-        [[ -z "$line" ]] && continue
-        local name attached activity
-        read -r name attached activity <<< "$line"
-
-        [[ "$name" =~ $(all_menu_session_pattern) ]] || continue
-
-        session_names+=("$name")
-        if [[ "$attached" -gt 0 ]]; then
-            session_states+=("attached")
-        else
-            session_states+=("idle")
-        fi
-        session_activities+=("$activity")
-    done < <(tmux list-sessions -F '#{session_name} #{session_attached} #{session_activity}' 2>/dev/null || true)
-}
-
-match_sessions() {
-    orphaned_sessions=()
-
-    for si in "${!session_names[@]}"; do
-        local sname="${session_names[$si]}"
-        local sstate="${session_states[$si]}"
-        local sactivity="${session_activities[$si]}"
-        local found=false
-
-        for ei in "${!entries[@]}"; do
-            IFS='|' read -r repo_name branch path _state _activity <<< "${entries[$ei]}"
-            local expected_session
-            expected_session=$(code_agent_session_name "$path")
-
-            if [[ "$sname" == "$expected_session" ]]; then
-                entries[$ei]="${repo_name}|${branch}|${path}|${sstate}|${sactivity}"
-                found=true
-                break
-            fi
-        done
-
-        if [[ "$found" == false ]]; then
-            orphaned_sessions+=("${sname}|${sstate}|${sactivity}")
-        fi
-    done
-}
-
-compute_default() {
-    default_idx=0
-
-    [[ ${#entries[@]} -eq 0 ]] && return
-
-    local best_idx=-1
-    local best_activity=0
-
-    for i in "${!entries[@]}"; do
-        IFS='|' read -r _ _ _ state activity <<< "${entries[$i]}"
-        if [[ "$state" == "idle" && "$activity" -gt "$best_activity" ]]; then
-            best_activity="$activity"
-            best_idx=$i
-        fi
-    done
-
-    if [[ $best_idx -ge 0 ]]; then
-        default_idx=$best_idx
-    fi
-}
-
-# --- Compact menu rendering --------------------------------------------------
-
-show_menu() {
-    local prev_repo=""
-    local idx=1
-    local next_agent
-    next_agent=$(next_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
-
-    echo ""
-
-    if [[ ${#entries[@]} -eq 0 ]]; then
-        echo "  (no repos — press m to clone)"
-    else
-        for i in "${!entries[@]}"; do
-            IFS='|' read -r repo_name branch path state activity <<< "${entries[$i]}"
-
-            if [[ "$repo_name" != "$prev_repo" ]]; then
-                [[ -n "$prev_repo" ]] && echo ""
-                echo "  ${repo_name}"
-                prev_repo="$repo_name"
-            fi
-
-            local marker=""
-            if [[ "$state" == "idle" ]]; then
-                marker="  <- active (idle)"
-            elif [[ "$state" == "attached" ]]; then
-                marker="  <- active (attached)"
-            fi
-
-            echo "  [${idx}] ${branch}${marker}"
-            ((idx++))
-        done
-    fi
-
-    if [[ ${#orphaned_sessions[@]} -gt 0 ]]; then
-        echo ""
-        echo "  sessions"
-        for os in "${orphaned_sessions[@]}"; do
-            IFS='|' read -r sname sstate _ <<< "$os"
-            local omarker=""
-            [[ "$sstate" == "attached" ]] && omarker="  <- active (attached)"
-            [[ "$sstate" == "idle" ]] && omarker="  <- active (idle)"
-            echo "  [${idx}] ${sname}${omarker}"
-            ((idx++))
-        done
-    fi
-
-    echo ""
-    if [[ ${#entries[@]} -eq 0 ]]; then
-        echo "  Enter=m  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage  h=shell"
-    else
-        local default_display=$(( default_idx + 1 ))
-        echo "  Enter=${default_display}  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage  h=shell"
-    fi
-    echo ""
-}
-
-# --- Entry selection: reattach or launch -------------------------------------
-
-select_entry() {
-    local idx="$1"
-
-    if [[ $idx -lt ${#entries[@]} ]]; then
-        IFS='|' read -r _ _ path state _ <<< "${entries[$idx]}"
-        local session_name
-        session_name=$(code_agent_session_name "$path")
-
-        if [[ "$state" == "idle" || "$state" == "attached" ]]; then
-            echo "  -> $session_name"
-            echo ""
-            tmux attach-session -t "$session_name"
-        else
-            launch "$path" || return 1
-        fi
-    else
-        local oi=$(( idx - ${#entries[@]} ))
-        IFS='|' read -r sname _ _ <<< "${orphaned_sessions[$oi]}"
-        echo "  -> $sname"
-        echo ""
-        tmux attach-session -t "$sname"
-    fi
-}
-
-# --- Launch the preferred code agent directly in tmux ------------------------
-
 launch() {
     local selected="$1"
     local session_name
@@ -488,8 +136,6 @@ launch() {
         "bash -lc 'exec bash \"$RUNNER\" --agent \"$CODE_AGENT\" --cwd \"$selected\"'"
 }
 
-# --- Launch Claude for workspace management ----------------------------------
-
 launch_manager() {
     local dir="$1"
     local session_name="claude-manager"
@@ -505,48 +151,25 @@ launch_manager() {
         "bash -lc 'exec bash \"$RUNNER\" --agent claude --cwd \"$dir\" --prompt-file \"$MANAGER_PROMPT\" --message \"Greet me and show what you can help with.\"'"
 }
 
-# --- Launch a shell in tmux ---------------------------------------------------
-
 launch_shell() {
     echo "  -> shell"
     echo ""
     tmux new-session -A -s "shell-local" "bash -l"
 }
 
-# --- Main ---------------------------------------------------------------------
+before_picker_loop() {
+    first_run_check
+}
 
-first_run_check
-
-while true; do
-    discover_entries
-    get_sessions
-    match_sessions
-    compute_default
-    show_menu
-
-    read -r -p "  > " choice || true
-
-    if [[ "$choice" == "m" ]]; then
-        launch_manager "$DEV_ENV" || true
-        continue
-    elif [[ "$choice" == "t" ]]; then
-        toggle_code_agent
-        continue
-    elif [[ "$choice" == "h" ]]; then
+handle_extra_choice() {
+    local choice="$1"
+    if [[ "$choice" == "h" ]]; then
         launch_shell
-        continue
-    elif [[ -z "$choice" ]]; then
-        if [[ ${#entries[@]} -eq 0 ]]; then
-            launch_manager "$DEV_ENV" || true
-        else
-            select_entry "$default_idx" || true
-        fi
-        continue
-    elif [[ "$choice" =~ ^[0-9]+$ ]]; then
-        idx=$(( choice - 1 ))
-        total=$(( ${#entries[@]} + ${#orphaned_sessions[@]} ))
-        if [[ $idx -ge 0 && $idx -lt $total ]]; then
-            select_entry "$idx" || true
-        fi
+        return 0
     fi
-done
+    return 1
+}
+
+if [[ "${START_MENU_TESTING:-0}" != "1" ]]; then
+    run_picker_loop
+fi

--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 COMPOSE_DIR="${DEV_ENV:-$HOME/dev-env}"
+COMMON_LIB="$COMPOSE_DIR/scripts/lib/start-menu-common.sh"
 
-# Load config if available
 if [[ -f "$COMPOSE_DIR/scripts/deploy/load-config.sh" ]]; then
     # shellcheck disable=SC1091
     source "$COMPOSE_DIR/scripts/deploy/load-config.sh"
@@ -25,20 +25,13 @@ RUNNER_HOST="$COMPOSE_DIR/scripts/runtime/run-code-agent.sh"
 RUNNER_CONTAINER="/home/dev/dev-env/scripts/runtime/run-code-agent.sh"
 
 COMPOSE_CMD=(sudo --preserve-env=HOME docker compose)
+MANAGER_TARGET="$COMPOSE_DIR"
+MENU_ACTIONS="h=host  c=container"
 
-normalize_code_agent() {
-    case "${1:-}" in
-        codex) echo "codex" ;;
-        claude|"") echo "claude" ;;
-        *) echo "claude" ;;
-    esac
-}
+# shellcheck disable=SC1091
+source "$COMMON_LIB"
 
 CODE_AGENT=$(normalize_code_agent "${DEFAULT_CODE_AGENT:-claude}")
-
-all_code_agent_session_pattern() {
-    echo '^(claude|codex)-'
-}
 
 file_sha256() {
     local path="$1"
@@ -111,139 +104,6 @@ ensure_claude_state_mount_current() {
     return 0
 }
 
-next_code_agent() {
-    local agent
-    agent=$(normalize_code_agent "${1:-${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}}")
-    if [[ "$agent" == "codex" ]]; then
-        echo "claude"
-    else
-        echo "codex"
-    fi
-}
-
-persist_default_code_agent() {
-    local agent profile tmp
-    agent=$(normalize_code_agent "${1:-claude}")
-    profile="$HOME/.bash_profile"
-
-    touch "$profile"
-
-    tmp=$(mktemp)
-    awk -v agent="$agent" '
-        BEGIN {
-            updated = 0
-            comment = "# Default coding assistant for the workspace picker"
-            export_line = "export DEFAULT_CODE_AGENT=\"" agent "\""
-        }
-        /^export DEFAULT_CODE_AGENT=/ {
-            if (!updated) {
-                print export_line
-                updated = 1
-            }
-            next
-        }
-        { print }
-        END {
-            if (!updated) {
-                if (NR > 0) {
-                    print ""
-                }
-                print comment
-                print export_line
-            }
-        }
-    ' "$profile" > "$tmp"
-    cat "$tmp" > "$profile"
-    rm -f "$tmp"
-
-    DEFAULT_CODE_AGENT="$agent"
-    CODE_AGENT="$agent"
-    export DEFAULT_CODE_AGENT CODE_AGENT
-}
-
-toggle_code_agent() {
-    local next_agent
-    next_agent=$(next_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
-    persist_default_code_agent "$next_agent"
-    echo ""
-    echo "  Default agent set to: $CODE_AGENT"
-    echo ""
-}
-
-code_agent_session_name() {
-    local path="$1"
-    local agent
-    agent=$(normalize_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
-    echo "${agent}-$(basename "$path" | tr './:' '-')"
-}
-
-# --- tmux prefix detection ---
-tmux_detach_hint() {
-    local prefix
-    prefix=$(tmux show-option -gv prefix 2>/dev/null || echo "C-b")
-    local pretty
-    pretty=$(echo "$prefix" | sed 's/C-/Ctrl-/')
-    echo "${pretty} d"
-}
-
-# --- Session limit helpers ---
-count_sessions() {
-    tmux list-sessions -F '#{session_name}' 2>/dev/null \
-        | grep -Ec "$(all_code_agent_session_pattern)" || true
-}
-
-get_max_sessions() {
-    # Env var override
-    if [[ -n "${MAX_SESSIONS:-}" ]]; then
-        echo "$MAX_SESSIONS"
-        return
-    fi
-
-    # Auto-calculate: min(memory_based, cpu_count), minimum 1
-    # Reserve 512MB for OS (Docker + SSH + earlyoom), ~650MB per coding session
-    local total_mem_mb cpus mem_based max
-    if [[ -f /proc/meminfo ]]; then
-        total_mem_mb=$(awk '/MemTotal/ {printf "%.0f", $2/1024}' /proc/meminfo)
-    elif command -v sysctl &>/dev/null; then
-        total_mem_mb=$(sysctl -n hw.memsize 2>/dev/null | awk '{printf "%.0f", $1/1024/1024}')
-    else
-        total_mem_mb=4096
-    fi
-
-    cpus=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
-    mem_based=$(( (total_mem_mb - 512) / 650 ))
-    [[ $mem_based -lt 1 ]] && mem_based=1
-
-    max=$(( mem_based < cpus ? mem_based : cpus ))
-    [[ $max -lt 1 ]] && max=1
-    echo "$max"
-}
-
-check_session_limit() {
-    local session_name="$1"
-    # Always allow re-attaching to an existing session
-    if tmux has-session -t "$session_name" 2>/dev/null; then
-        return 0
-    fi
-    # Check limit for new sessions
-    local current max
-    current=$(count_sessions)
-    max=$(get_max_sessions)
-    if [[ $current -ge $max ]]; then
-        echo ""
-        echo "  Session limit reached ($current/$max)."
-        echo "  Each coding session uses ~650 MB — more sessions risk OOM."
-        echo ""
-        echo "  Options:"
-        echo "    - Re-attach to an existing session (select it from the menu)"
-        echo "    - Exit a running session ($(tmux_detach_hint) to detach, then /exit inside it)"
-        echo ""
-        return 1
-    fi
-    return 0
-}
-
-# --- Background container check ---
 container_pid=""
 
 ensure_container_bg() {
@@ -282,244 +142,10 @@ wait_for_container() {
     return 1
 }
 
-# --- Translate host path to container path ---
 to_container_path() {
     echo "${1/$HOME\/projects/$CONTAINER_PROJECTS}"
 }
 
-normalize_discovered_path() {
-    local path="$1"
-    if [[ "$path" == /private/* && -e "${path#/private}" ]]; then
-        echo "${path#/private}"
-    else
-        echo "$path"
-    fi
-}
-
-# --- Inline discovery (flat: repos + worktrees in one pass) ---
-discover_entries() {
-    entries=()
-    local repo_dirs=()
-    if command -v mapfile >/dev/null 2>&1; then
-        mapfile -t repo_dirs < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
-    else
-        local repo_dir
-        while IFS= read -r repo_dir; do
-            [[ -n "$repo_dir" ]] && repo_dirs+=("$repo_dir")
-        done < <(find "$PROJECTS_DIR" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
-    fi
-
-    [[ ${#repo_dirs[@]} -eq 0 ]] && return
-
-    # Parallel git queries: branch + worktree discovery in one pass per repo
-    local tmpdir
-    tmpdir=$(mktemp -d)
-    for i in "${!repo_dirs[@]}"; do
-        local dir
-        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
-        (
-            branch=$(git -C "$dir" branch --show-current 2>/dev/null || echo "unknown")
-            echo "$branch" > "$tmpdir/${i}.branch"
-            git -C "$dir" worktree list --porcelain 2>/dev/null > "$tmpdir/${i}.worktrees" || true
-        ) &
-    done
-    wait
-
-    for i in "${!repo_dirs[@]}"; do
-        local dir
-        dir=$(normalize_discovered_path "$(dirname "${repo_dirs[$i]}")")
-        local branch
-        branch=$(cat "$tmpdir/${i}.branch")
-        local repo_name
-        repo_name=$(basename "$dir")
-
-        # Add main repo entry: repo_name|branch|path|session_state|session_activity
-        entries+=("${repo_name}|${branch}|${dir}|none|0")
-
-        # Parse worktrees from parallel results
-        local wt_path="" wt_branch=""
-        while IFS= read -r line; do
-            if [[ "$line" == "worktree "* ]]; then
-                wt_path=$(normalize_discovered_path "${line#worktree }")
-                wt_branch=""
-            elif [[ "$line" == "branch "* ]]; then
-                wt_branch="${line#branch refs/heads/}"
-            elif [[ -z "$line" ]]; then
-                if [[ "$wt_path" != "$dir" && -n "$wt_branch" ]]; then
-                    entries+=("${repo_name}|${wt_branch}|${wt_path}|none|0")
-                fi
-                wt_path=""
-                wt_branch=""
-            fi
-        done < <(cat "$tmpdir/${i}.worktrees"; echo)
-    done
-
-    rm -rf "$tmpdir"
-}
-
-# --- Session matching ---
-get_sessions() {
-    session_names=()
-    session_states=()
-    session_activities=()
-
-    local line
-    while IFS= read -r line; do
-        [[ -z "$line" ]] && continue
-        local name attached activity
-        read -r name attached activity <<< "$line"
-
-        # Only track coding assistant sessions
-        [[ "$name" =~ ^(claude|codex)- ]] || continue
-
-        session_names+=("$name")
-        if [[ "$attached" -gt 0 ]]; then
-            session_states+=("attached")
-        else
-            session_states+=("idle")
-        fi
-        session_activities+=("$activity")
-    done < <(tmux list-sessions -F '#{session_name} #{session_attached} #{session_activity}' 2>/dev/null || true)
-}
-
-match_sessions() {
-    orphaned_sessions=()
-
-    for si in "${!session_names[@]}"; do
-        local sname="${session_names[$si]}"
-        local sstate="${session_states[$si]}"
-        local sactivity="${session_activities[$si]}"
-        local found=false
-
-        for ei in "${!entries[@]}"; do
-            IFS='|' read -r repo_name branch path _state _activity <<< "${entries[$ei]}"
-            local expected_session
-            expected_session=$(code_agent_session_name "$path")
-
-            if [[ "$sname" == "$expected_session" ]]; then
-                entries[$ei]="${repo_name}|${branch}|${path}|${sstate}|${sactivity}"
-                found=true
-                break
-            fi
-        done
-
-        if [[ "$found" == false ]]; then
-            orphaned_sessions+=("${sname}|${sstate}|${sactivity}")
-        fi
-    done
-}
-
-# --- Smart default ---
-compute_default() {
-    default_idx=0
-
-    [[ ${#entries[@]} -eq 0 ]] && return
-
-    # Find the most recently active idle session
-    local best_idx=-1
-    local best_activity=0
-
-    for i in "${!entries[@]}"; do
-        IFS='|' read -r _ _ _ state activity <<< "${entries[$i]}"
-        if [[ "$state" == "idle" && "$activity" -gt "$best_activity" ]]; then
-            best_activity="$activity"
-            best_idx=$i
-        fi
-    done
-
-    if [[ $best_idx -ge 0 ]]; then
-        default_idx=$best_idx
-    fi
-}
-
-# --- Compact menu rendering ---
-show_menu() {
-    local prev_repo=""
-    local idx=1
-    local next_agent
-    next_agent=$(next_code_agent "${CODE_AGENT:-${DEFAULT_CODE_AGENT:-claude}}")
-
-    echo ""
-
-    if [[ ${#entries[@]} -eq 0 ]]; then
-        echo "  (no repos — press m to clone)"
-    else
-        for i in "${!entries[@]}"; do
-            IFS='|' read -r repo_name branch path state activity <<< "${entries[$i]}"
-
-            # Print repo header when repo changes
-            if [[ "$repo_name" != "$prev_repo" ]]; then
-                [[ -n "$prev_repo" ]] && echo ""
-                echo "  ${repo_name}"
-                prev_repo="$repo_name"
-            fi
-
-            # Branch line with optional session marker
-            local marker=""
-            if [[ "$state" == "idle" ]]; then
-                marker="  ← active (idle)"
-            elif [[ "$state" == "attached" ]]; then
-                marker="  ← active (attached)"
-            fi
-
-            echo "  [${idx}] ${branch}${marker}"
-            ((idx++))
-        done
-    fi
-
-    # Orphaned sessions
-    if [[ ${#orphaned_sessions[@]} -gt 0 ]]; then
-        echo ""
-        echo "  sessions"
-        for os in "${orphaned_sessions[@]}"; do
-            IFS='|' read -r sname sstate _ <<< "$os"
-            local omarker=""
-            [[ "$sstate" == "attached" ]] && omarker="  ← active (attached)"
-            [[ "$sstate" == "idle" ]] && omarker="  ← active (idle)"
-            echo "  [${idx}] ${sname}${omarker}"
-            ((idx++))
-        done
-    fi
-
-    # Footer
-    echo ""
-    if [[ ${#entries[@]} -eq 0 ]]; then
-        echo "  Enter=m  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage  h=host  c=container"
-    else
-        local default_display=$(( default_idx + 1 ))
-        echo "  Enter=${default_display}  agent=${CODE_AGENT}  t=toggle->${next_agent}  m=manage  h=host  c=container"
-    fi
-    echo ""
-}
-
-# --- Entry selection (unified: re-attach or new session) ---
-select_entry() {
-    local idx="$1"
-
-    if [[ $idx -lt ${#entries[@]} ]]; then
-        IFS='|' read -r _ _ path state _ <<< "${entries[$idx]}"
-        local session_name
-        session_name=$(code_agent_session_name "$path")
-
-        if [[ "$state" == "idle" || "$state" == "attached" ]]; then
-            echo "  -> $session_name"
-            echo ""
-            tmux attach-session -t "$session_name"
-        else
-            wait_for_container || return 1
-            launch "$path" || return 1
-        fi
-    else
-        # Orphaned session
-        local oi=$(( idx - ${#entries[@]} ))
-        IFS='|' read -r sname _ _ <<< "${orphaned_sessions[$oi]}"
-        echo "  -> $sname"
-        echo ""
-        tmux attach-session -t "$sname"
-    fi
-}
-
-# --- Launch Claude Code in selected workspace (inside container) ---
 launch() {
     local selected="$1"
     local container_path
@@ -545,8 +171,7 @@ launch() {
         "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -e OPENAI_API_KEY=\"${OPENAI_API_KEY:-}\" -e ANTHROPIC_API_KEY=\"${ANTHROPIC_API_KEY:-}\" -e DEFAULT_CODE_AGENT=\"$CODE_AGENT\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'exec bash \"$RUNNER_CONTAINER\" --agent \"$CODE_AGENT\"'"
 }
 
-# --- Launch Claude on the host (for workspace management / updates) ---
-launch_host() {
+launch_manager() {
     local dir="$1"
     local session_name="claude-manager"
 
@@ -562,14 +187,12 @@ launch_host() {
         "bash -lc 'exec bash \"$RUNNER_HOST\" --agent claude --cwd \"$dir\" --prompt-file \"$MANAGER_PROMPT\" --message \"Greet me and show what you can help with.\"'"
 }
 
-# --- Launch a host shell in tmux ---
 launch_shell_host() {
     echo "  -> host shell"
     echo ""
     tmux new-session -A -s "shell-host" "bash -l"
 }
 
-# --- Launch a container shell in tmux ---
 launch_shell_container() {
     echo "  -> container shell"
     echo ""
@@ -577,47 +200,31 @@ launch_shell_container() {
         "docker exec -it ${CONTAINER_NAME} bash -l"
 }
 
-# --- Main ---
-ensure_container_bg
+prepare_project_launch() {
+    wait_for_container
+}
 
-while true; do
-    # Refresh repos and session state each iteration
-    discover_entries
-    get_sessions
-    match_sessions
-    compute_default
-    show_menu
+prepare_manager_launch() {
+    wait_for_container
+}
 
-    read -r -p "  > " choice || true
+before_picker_loop() {
+    ensure_container_bg
+}
 
-    if [[ "$choice" == "m" ]]; then
-        wait_for_container || continue
-        launch_host "$COMPOSE_DIR" || true
-        continue
-    elif [[ "$choice" == "t" ]]; then
-        toggle_code_agent
-        continue
-    elif [[ "$choice" == "h" ]]; then
+handle_extra_choice() {
+    local choice="$1"
+    if [[ "$choice" == "h" ]]; then
         launch_shell_host
-        continue
+        return 0
     elif [[ "$choice" == "c" ]]; then
-        wait_for_container || continue
+        prepare_project_launch || return 0
         launch_shell_container
-        continue
-    elif [[ -z "$choice" ]]; then
-        # Smart default
-        if [[ ${#entries[@]} -eq 0 ]]; then
-            wait_for_container || continue
-            launch_host "$COMPOSE_DIR" || true
-            continue
-        else
-            select_entry "$default_idx" || continue
-        fi
-    elif [[ "$choice" =~ ^[0-9]+$ ]]; then
-        idx=$(( choice - 1 ))
-        total=$(( ${#entries[@]} + ${#orphaned_sessions[@]} ))
-        if [[ $idx -ge 0 && $idx -lt $total ]]; then
-            select_entry "$idx" || continue
-        fi
+        return 0
     fi
-done
+    return 1
+}
+
+if [[ "${START_MENU_TESTING:-0}" != "1" ]]; then
+    run_picker_loop
+fi

--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -25,10 +25,13 @@ RUNNER_HOST="$COMPOSE_DIR/scripts/runtime/run-code-agent.sh"
 RUNNER_CONTAINER="/home/dev/dev-env/scripts/runtime/run-code-agent.sh"
 
 COMPOSE_CMD=(sudo --preserve-env=HOME docker compose)
+# Shared picker config consumed by scripts/lib/start-menu-common.sh.
+# shellcheck disable=SC2034
 MANAGER_TARGET="$COMPOSE_DIR"
+# shellcheck disable=SC2034
 MENU_ACTIONS="h=host  c=container"
 
-# shellcheck disable=SC1091
+# shellcheck source=../lib/start-menu-common.sh
 source "$COMMON_LIB"
 
 CODE_AGENT=$(normalize_code_agent "${DEFAULT_CODE_AGENT:-claude}")

--- a/scripts/runtime/update-macmini.sh
+++ b/scripts/runtime/update-macmini.sh
@@ -70,7 +70,7 @@ info "Verify"
 "$DOCKER" image inspect ghcr.io/verkyyi/always-on-claude:latest --format \
   '  Created={{.Created}} Revision={{index .Config.Labels "org.opencontainers.image.revision"}}'
 "$DOCKER" exec "$CONTAINER" bash -lc \
-  'claude --version; node --version; gh --version | head -1; git --version'
+  'claude --version; codex --version; node --version; gh --version | head -1; git --version'
 
 info "Cleanup"
 "$DOCKER" image prune -f >/dev/null 2>&1 || true

--- a/scripts/runtime/upgrade-code-agents.sh
+++ b/scripts/runtime/upgrade-code-agents.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# upgrade-code-agents.sh — Update Claude Code and Codex in a user-writable way.
+#
+# Intended for container startup. This script must be safe to run as the
+# non-root dev user: Claude uses its native user-local updater, and Codex is
+# installed into ~/.local so it shadows the root-owned image package.
+
+set -euo pipefail
+
+info() { printf '\n=== %s ===\n' "$*"; }
+ok() { printf '  OK: %s\n' "$*"; }
+warn() { printf '  WARN: %s\n' "$*" >&2; }
+
+if [[ "${AOC_AUTO_UPGRADE_AGENTS:-1}" == "0" ]]; then
+    ok "Agent auto-upgrade disabled"
+    exit 0
+fi
+
+if [[ "$(id -u)" -eq 0 ]]; then
+    warn "Run as the workspace user, not root; skipping agent upgrade"
+    exit 0
+fi
+
+export NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-$HOME/.local}"
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+
+mkdir -p "$NPM_CONFIG_PREFIX/bin" "$HOME/.cache/aoc"
+
+info "Claude Code"
+if command -v claude >/dev/null 2>&1; then
+    before=$(claude --version 2>/dev/null || true)
+    if claude update >/dev/null 2>&1; then
+        after=$(claude --version 2>/dev/null || true)
+        if [[ -n "$before" && -n "$after" && "$before" != "$after" ]]; then
+            ok "$before -> $after"
+        else
+            ok "${after:-up to date}"
+        fi
+    else
+        warn "Claude update failed; keeping current version${before:+ ($before)}"
+    fi
+else
+    warn "claude is not installed"
+fi
+
+info "Codex"
+if command -v npm >/dev/null 2>&1; then
+    before=$(codex --version 2>/dev/null || true)
+    if npm install -g @openai/codex@latest >/dev/null 2>&1; then
+        hash -r
+        after=$(codex --version 2>/dev/null || true)
+        if [[ -n "$before" && -n "$after" && "$before" != "$after" ]]; then
+            ok "$before -> $after"
+        else
+            ok "${after:-up to date}"
+        fi
+    else
+        warn "Codex update failed; keeping current version${before:+ ($before)}"
+    fi
+else
+    warn "npm is not installed"
+fi

--- a/tests/test-start-claude-portable.sh
+++ b/tests/test-start-claude-portable.sh
@@ -4,16 +4,27 @@
 PORTABLE_SCRIPT="$REPO_ROOT/scripts/portable/start-claude-portable.sh"
 
 _source_functions() {
-    eval "$(sed -n '/^all_code_agent_session_pattern()/,/^}/p' "$PORTABLE_SCRIPT")"
-    eval "$(sed -n '/^count_sessions()/,/^}/p' "$PORTABLE_SCRIPT")"
-    eval "$(sed -n '/^get_max_sessions()/,/^}/p' "$PORTABLE_SCRIPT")"
-    eval "$(sed -n '/^tmux_detach_hint()/,/^}/p' "$PORTABLE_SCRIPT")"
-    eval "$(sed -n '/^check_session_limit()/,/^}/p' "$PORTABLE_SCRIPT")"
+    export DEV_ENV="$REPO_ROOT"
+    export DEFAULT_CODE_AGENT="${DEFAULT_CODE_AGENT:-claude}"
+    export CODE_AGENT="${CODE_AGENT:-$DEFAULT_CODE_AGENT}"
+    START_MENU_TESTING=1
+    # shellcheck disable=SC1090
+    source "$PORTABLE_SCRIPT"
+    unset START_MENU_TESTING
+}
+
+_source_v2() {
+    export PROJECTS_DIR="$HOME/projects"
+    _source_functions
 }
 
 setup() {
+    mkdir -p "$HOME/projects"
+    mock_binary tmux ""
+    mock_binary nproc "2"
+    unset DEFAULT_CODE_AGENT CODE_AGENT MAX_SESSIONS
     _source_functions
-    unset MAX_SESSIONS
+    _source_v2
 }
 
 test_max_sessions_env_override() {
@@ -73,4 +84,165 @@ MOCK
     assert_eq "1" "$exit_code"
     assert_contains "$output" "Session limit reached (1/1)"
     assert_contains "$output" "Ctrl-b d"
+}
+
+test_get_sessions_filters_non_agent() {
+    cat > "$TEST_DIR/bin/tmux" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "list-sessions" ]]; then
+    echo "claude-myrepo 0 1711612800"
+    echo "codex-other 0 1711612500"
+    echo "shell-local 0 1711612000"
+    echo "other-session 0 1711611000"
+fi
+MOCK
+    chmod +x "$TEST_DIR/bin/tmux"
+    _source_v2
+
+    get_sessions
+    assert_eq "3" "${#session_names[@]}"
+}
+
+test_match_sessions_collapses_worktrees_to_latest_project_session() {
+    entries=(
+        "myrepo|main|/home/dev/projects/myrepo|none|0"
+        "myrepo|feature-x|/home/dev/projects/myrepo-feature-x|none|0"
+    )
+    session_names=("claude-myrepo-feature-x")
+    session_states=("idle")
+    session_activities=("1711612800")
+    _source_v2
+
+    orphaned_sessions=()
+    match_sessions
+    assert_eq "1" "${#project_entries[@]}"
+    IFS='|' read -r name main_branch main_path selected_branch selected_path state activity <<< "${project_entries[0]}"
+    assert_eq "myrepo" "$name"
+    assert_eq "main" "$main_branch"
+    assert_eq "/home/dev/projects/myrepo" "$main_path"
+    assert_eq "feature-x" "$selected_branch"
+    assert_eq "/home/dev/projects/myrepo-feature-x" "$selected_path"
+    assert_eq "idle" "$state"
+    assert_eq "1711612800" "$activity"
+}
+
+test_match_sessions_uses_selected_agent_prefix() {
+    entries=("myrepo|main|/home/dev/projects/myrepo|none|0")
+    session_names=("codex-myrepo")
+    session_states=("idle")
+    session_activities=("1711612800")
+    DEFAULT_CODE_AGENT=codex
+    CODE_AGENT=codex
+    _source_functions
+    _source_v2
+
+    orphaned_sessions=()
+    match_sessions
+    IFS='|' read -r _ _ _ selected_branch selected_path state activity <<< "${project_entries[0]}"
+    assert_eq "main" "$selected_branch"
+    assert_eq "/home/dev/projects/myrepo" "$selected_path"
+    assert_eq "idle" "$state"
+    assert_eq "1711612800" "$activity"
+}
+
+test_compute_default_prefers_idle() {
+    project_entries=(
+        "app1|main|/path/app1|main|/path/app1|none|0"
+        "app2|main|/path/app2|main|/path/app2|idle|1711612800"
+    )
+    _source_v2
+
+    compute_default
+    assert_eq "1" "$default_idx"
+}
+
+test_compute_default_uses_attached_when_no_idle_session_exists() {
+    project_entries=(
+        "app1|main|/path/app1|main|/path/app1|attached|1711613000"
+        "app2|main|/path/app2|main|/path/app2|attached|1711612800"
+    )
+    _source_v2
+
+    compute_default
+    assert_eq "0" "$default_idx"
+}
+
+test_show_menu_project_line() {
+    project_entries=("myrepo|main|/path/myrepo|main|/path/myrepo|none|0")
+    orphaned_sessions=()
+    default_idx=0
+    _source_v2
+
+    local output
+    output=$(show_menu)
+    assert_contains "$output" "[1] myrepo  main"
+}
+
+test_show_menu_active_marker() {
+    project_entries=("myrepo|main|/path/myrepo|feature-x|/path/myrepo-feature-x|idle|1711612800")
+    orphaned_sessions=()
+    default_idx=0
+    _source_v2
+
+    local output
+    output=$(show_menu)
+    assert_contains "$output" "[1] myrepo  feature-x  active"
+}
+
+test_show_menu_footer() {
+    project_entries=("myrepo|main|/path/myrepo|main|/path/myrepo|none|0")
+    orphaned_sessions=()
+    default_idx=0
+    _source_v2
+
+    local output
+    output=$(show_menu)
+    assert_contains "$output" "Enter=1"
+    assert_contains "$output" "m=manage"
+    assert_contains "$output" "h=shell"
+}
+
+test_show_menu_no_repos() {
+    project_entries=()
+    orphaned_sessions=()
+    default_idx=0
+    _source_v2
+
+    local output
+    output=$(show_menu)
+    assert_contains "$output" "no repos"
+    assert_contains "$output" "Enter=m"
+}
+
+test_select_entry_resumes_project_session() {
+    project_entries=("myrepo|main|/path/myrepo|feature-x|/path/myrepo-feature-x|idle|1711612800")
+    orphaned_sessions=()
+    _source_v2
+
+    cat > "$TEST_DIR/bin/tmux" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "attach-session" && "$2" == "-t" && "$3" == "claude-myrepo-feature-x" ]]; then
+    exit 0
+fi
+exit 99
+MOCK
+    chmod +x "$TEST_DIR/bin/tmux"
+
+    local output
+    output=$(select_entry 0 2>&1)
+    assert_contains "$output" "claude-myrepo-feature-x"
+}
+
+test_select_entry_launches_main_path_when_no_session_exists() {
+    project_entries=("myrepo|main|/path/myrepo|feature-x|/path/myrepo-feature-x|none|0")
+    orphaned_sessions=()
+    _source_v2
+
+    launch() {
+        echo "launch:$1"
+    }
+
+    local output
+    output=$(select_entry 0 2>&1)
+    assert_contains "$output" "launch:/path/myrepo"
 }

--- a/tests/test-start-claude.sh
+++ b/tests/test-start-claude.sh
@@ -4,37 +4,22 @@
 START_SCRIPT="$REPO_ROOT/scripts/runtime/start-claude.sh"
 
 _source_functions() {
-    export COMPOSE_DIR="$HOME/dev-env"
+    export DEV_ENV="$REPO_ROOT"
+    export COMPOSE_DIR="$REPO_ROOT"
     export CONTAINER_NAME="claude-dev"
     export CONTAINER_PROJECTS="/home/dev/projects"
     export DEFAULT_CODE_AGENT="${DEFAULT_CODE_AGENT:-claude}"
     export CODE_AGENT="${CODE_AGENT:-$DEFAULT_CODE_AGENT}"
     COMPOSE_CMD=(sudo --preserve-env=HOME docker compose)
-
-    eval "$(sed -n '/^normalize_code_agent()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^file_sha256()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^container_file_sha256()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^refresh_container_after_recreate()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^ensure_claude_state_mount_current()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^all_code_agent_session_pattern()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^next_code_agent()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^persist_default_code_agent()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^toggle_code_agent()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^code_agent_session_name()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^count_sessions()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^get_max_sessions()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^check_session_limit()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^to_container_path()/,/^}/p' "$START_SCRIPT")"
-    eval "$(sed -n '/^normalize_discovered_path()/,/^}/p' "$START_SCRIPT")"
+    START_MENU_TESTING=1
+    # shellcheck disable=SC1090
+    source "$START_SCRIPT"
+    unset START_MENU_TESTING
 }
 
 _source_v2() {
     export PROJECTS_DIR="$HOME/projects"
-    eval "$(sed -n '/^discover_entries()/,/^}/p' "$START_SCRIPT")" 2>/dev/null || true
-    eval "$(sed -n '/^get_sessions()/,/^}/p' "$START_SCRIPT")" 2>/dev/null || true
-    eval "$(sed -n '/^match_sessions()/,/^}/p' "$START_SCRIPT")" 2>/dev/null || true
-    eval "$(sed -n '/^compute_default()/,/^}/p' "$START_SCRIPT")" 2>/dev/null || true
-    eval "$(sed -n '/^show_menu()/,/^}/p' "$START_SCRIPT")" 2>/dev/null || true
+    _source_functions
 }
 
 setup() {
@@ -426,7 +411,12 @@ test_match_sessions_annotates_entry() {
 
     orphaned_sessions=()
     match_sessions
-    IFS='|' read -r _ _ _ state activity <<< "${entries[0]}"
+    IFS='|' read -r name main_branch main_path selected_branch selected_path state activity <<< "${project_entries[0]}"
+    assert_eq "myrepo" "$name"
+    assert_eq "main" "$main_branch"
+    assert_eq "/home/dev/projects/myrepo" "$main_path"
+    assert_eq "main" "$selected_branch"
+    assert_eq "/home/dev/projects/myrepo" "$selected_path"
     assert_eq "idle" "$state"
     assert_eq "1711612800" "$activity"
     assert_eq "0" "${#orphaned_sessions[@]}" "matching session should not be orphaned"
@@ -457,16 +447,41 @@ test_match_sessions_uses_selected_agent_prefix() {
 
     orphaned_sessions=()
     match_sessions
-    IFS='|' read -r _ _ _ state activity <<< "${entries[0]}"
+    IFS='|' read -r _ _ _ selected_branch selected_path state activity <<< "${project_entries[0]}"
+    assert_eq "main" "$selected_branch"
+    assert_eq "/home/dev/projects/myrepo" "$selected_path"
     assert_eq "idle" "$state"
     assert_eq "1711612800" "$activity"
     assert_eq "0" "${#orphaned_sessions[@]}"
 }
 
-test_compute_default_prefers_idle() {
+test_match_sessions_collapses_worktrees_to_latest_project_session() {
     entries=(
-        "app1|main|/path/app1|none|0"
-        "app2|main|/path/app2|idle|1711612800"
+        "myrepo|main|/home/dev/projects/myrepo|none|0"
+        "myrepo|feature-x|/home/dev/projects/myrepo-feature-x|none|0"
+    )
+    session_names=("claude-myrepo-feature-x")
+    session_states=("idle")
+    session_activities=("1711612800")
+    _source_v2
+
+    orphaned_sessions=()
+    match_sessions
+    assert_eq "1" "${#project_entries[@]}" "worktrees should collapse to one project summary"
+    IFS='|' read -r name main_branch main_path selected_branch selected_path state activity <<< "${project_entries[0]}"
+    assert_eq "myrepo" "$name"
+    assert_eq "main" "$main_branch"
+    assert_eq "/home/dev/projects/myrepo" "$main_path"
+    assert_eq "feature-x" "$selected_branch"
+    assert_eq "/home/dev/projects/myrepo-feature-x" "$selected_path"
+    assert_eq "idle" "$state"
+    assert_eq "1711612800" "$activity"
+}
+
+test_compute_default_prefers_idle() {
+    project_entries=(
+        "app1|main|/path/app1|main|/path/app1|none|0"
+        "app2|main|/path/app2|main|/path/app2|idle|1711612800"
     )
     _source_v2
 
@@ -475,9 +490,9 @@ test_compute_default_prefers_idle() {
 }
 
 test_compute_default_most_recent_idle() {
-    entries=(
-        "app1|main|/path/app1|idle|1711612000"
-        "app2|main|/path/app2|idle|1711612800"
+    project_entries=(
+        "app1|main|/path/app1|main|/path/app1|idle|1711612000"
+        "app2|main|/path/app2|main|/path/app2|idle|1711612800"
     )
     _source_v2
 
@@ -486,9 +501,9 @@ test_compute_default_most_recent_idle() {
 }
 
 test_compute_default_no_sessions_first_entry() {
-    entries=(
-        "app1|main|/path/app1|none|0"
-        "app2|dev|/path/app2|none|0"
+    project_entries=(
+        "app1|main|/path/app1|main|/path/app1|none|0"
+        "app2|dev|/path/app2|dev|/path/app2|none|0"
     )
     _source_v2
 
@@ -497,7 +512,7 @@ test_compute_default_no_sessions_first_entry() {
 }
 
 test_compute_default_empty_entries() {
-    entries=()
+    project_entries=()
     _source_v2
 
     compute_default
@@ -505,9 +520,9 @@ test_compute_default_empty_entries() {
 }
 
 test_compute_default_skips_attached() {
-    entries=(
-        "app1|main|/path/app1|attached|1711613000"
-        "app2|main|/path/app2|idle|1711612800"
+    project_entries=(
+        "app1|main|/path/app1|main|/path/app1|attached|1711613000"
+        "app2|main|/path/app2|main|/path/app2|idle|1711612800"
     )
     _source_v2
 
@@ -515,42 +530,52 @@ test_compute_default_skips_attached() {
     assert_eq "1" "$default_idx" "should prefer idle over attached even if attached is newer"
 }
 
-test_show_menu_repo_header_and_branch() {
-    entries=("myrepo|main|/path/myrepo|none|0")
+test_compute_default_uses_attached_when_no_idle_session_exists() {
+    project_entries=(
+        "app1|main|/path/app1|main|/path/app1|attached|1711613000"
+        "app2|main|/path/app2|main|/path/app2|attached|1711612800"
+    )
+    _source_v2
+
+    compute_default
+    assert_eq "0" "$default_idx" "should resume the newest attached session when no idle session exists"
+}
+
+test_show_menu_project_line() {
+    project_entries=("myrepo|main|/path/myrepo|main|/path/myrepo|none|0")
     orphaned_sessions=()
     default_idx=0
     _source_v2
 
     local output
     output=$(show_menu)
-    assert_contains "$output" "myrepo" "should show repo name as header"
-    assert_contains "$output" "[1] main" "should show branch as numbered item"
+    assert_contains "$output" "[1] myrepo  main" "should show project and branch on one line"
 }
 
 test_show_menu_active_marker() {
-    entries=("myrepo|main|/path/myrepo|idle|1711612800")
+    project_entries=("myrepo|main|/path/myrepo|feature-x|/path/myrepo-feature-x|idle|1711612800")
     orphaned_sessions=()
     default_idx=0
     _source_v2
 
     local output
     output=$(show_menu)
-    assert_contains "$output" "active (idle)" "should show active marker"
+    assert_contains "$output" "[1] myrepo  feature-x  active" "should show active marker on the project line"
 }
 
 test_show_menu_attached_marker() {
-    entries=("myrepo|main|/path/myrepo|attached|1711612800")
+    project_entries=("myrepo|main|/path/myrepo|feature-x|/path/myrepo-feature-x|attached|1711612800")
     orphaned_sessions=()
     default_idx=0
     _source_v2
 
     local output
     output=$(show_menu)
-    assert_contains "$output" "active (attached)" "should show attached marker"
+    assert_contains "$output" "[1] myrepo  feature-x  attached" "should show attached marker"
 }
 
 test_show_menu_footer_default() {
-    entries=("myrepo|main|/path/myrepo|none|0")
+    project_entries=("myrepo|main|/path/myrepo|main|/path/myrepo|none|0")
     orphaned_sessions=()
     default_idx=0
     _source_v2
@@ -565,7 +590,7 @@ test_show_menu_footer_default() {
 }
 
 test_show_menu_no_repos() {
-    entries=()
+    project_entries=()
     orphaned_sessions=()
     default_idx=0
     _source_v2
@@ -578,7 +603,7 @@ test_show_menu_no_repos() {
 }
 
 test_show_menu_footer_codex_toggle_target() {
-    entries=("myrepo|main|/path/myrepo|none|0")
+    project_entries=("myrepo|main|/path/myrepo|main|/path/myrepo|none|0")
     orphaned_sessions=()
     default_idx=0
     CODE_AGENT=codex
@@ -592,11 +617,10 @@ test_show_menu_footer_codex_toggle_target() {
     assert_contains "$output" "t=toggle->claude" "should show opposite agent"
 }
 
-test_show_menu_multiple_repos_grouped() {
-    entries=(
-        "app-one|main|/path/app-one|none|0"
-        "app-one|feature-x|/path/app-one--feature-x|none|0"
-        "app-two|dev|/path/app-two|none|0"
+test_show_menu_multiple_projects() {
+    project_entries=(
+        "app-one|main|/path/app-one|feature-x|/path/app-one--feature-x|idle|1711612800"
+        "app-two|dev|/path/app-two|dev|/path/app-two|none|0"
     )
     orphaned_sessions=()
     default_idx=0
@@ -604,15 +628,12 @@ test_show_menu_multiple_repos_grouped() {
 
     local output
     output=$(show_menu)
-    assert_contains "$output" "app-one" "should show first repo header"
-    assert_contains "$output" "[1] main" "should show first branch"
-    assert_contains "$output" "[2] feature-x" "should show worktree branch"
-    assert_contains "$output" "app-two" "should show second repo header"
-    assert_contains "$output" "[3] dev" "should show second repo branch"
+    assert_contains "$output" "[1] app-one  feature-x  active" "should show the first project summary"
+    assert_contains "$output" "[2] app-two  dev" "should show the second project summary"
 }
 
 test_show_menu_orphaned_sessions() {
-    entries=("myrepo|main|/path/myrepo|none|0")
+    project_entries=("myrepo|main|/path/myrepo|main|/path/myrepo|none|0")
     orphaned_sessions=("claude-deleted-repo|idle|0")
     default_idx=0
     _source_v2
@@ -621,4 +642,23 @@ test_show_menu_orphaned_sessions() {
     output=$(show_menu)
     assert_contains "$output" "sessions" "should show orphaned sessions header"
     assert_contains "$output" "claude-deleted-repo" "should show orphaned session name"
+}
+
+test_select_entry_resumes_project_session() {
+    project_entries=("myrepo|main|/path/myrepo|feature-x|/path/myrepo-feature-x|idle|1711612800")
+    orphaned_sessions=()
+    _source_v2
+
+    cat > "$TEST_DIR/bin/tmux" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "attach-session" && "$2" == "-t" && "$3" == "claude-myrepo-feature-x" ]]; then
+    exit 0
+fi
+exit 99
+MOCK
+    chmod +x "$TEST_DIR/bin/tmux"
+
+    local output
+    output=$(select_entry 0 2>&1)
+    assert_contains "$output" "claude-myrepo-feature-x"
 }


### PR DESCRIPTION
## Summary
- extract shared workspace picker logic into `scripts/lib/start-menu-common.sh`
- keep host and portable menu entrypoints as thin wrappers with mode-specific hooks
- add portable menu compaction/default-resume behavior and related macmini runtime updates

## Testing
- bash tests/run.sh tests/test-start-claude.sh
- bash tests/run.sh tests/test-start-claude-portable.sh