### PR TITLE
Fix Claude launch resume behavior

### DIFF
--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -136,7 +136,7 @@ launch() {
     echo ""
 
     tmux new-session -A -s "$session_name" \
-        "bash -lc 'exec bash \"$RUNNER\" --agent \"$CODE_AGENT\" --cwd \"$selected\"'"
+        "bash -lc 'exec bash \"$RUNNER\" --agent \"$CODE_AGENT\" --cwd \"$selected\" --resume-latest'"
 }
 
 launch_manager() {

--- a/scripts/runtime/run-code-agent.sh
+++ b/scripts/runtime/run-code-agent.sh
@@ -7,7 +7,7 @@
 #
 # Usage:
 #   bash run-code-agent.sh [--agent claude|codex] [--cwd DIR] \
-#       [--prompt-file FILE] [--message TEXT]
+#       [--prompt-file FILE] [--message TEXT] [--resume-latest]
 
 set -euo pipefail
 
@@ -25,6 +25,7 @@ agent="${DEFAULT_CODE_AGENT:-claude}"
 cwd=""
 prompt_file=""
 message=""
+resume_latest=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -47,6 +48,10 @@ while [[ $# -gt 0 ]]; do
             [[ $# -ge 2 ]] || die "--message requires a value"
             message="$2"
             shift 2
+            ;;
+        --resume-latest)
+            resume_latest=1
+            shift
             ;;
         *)
             die "Unknown argument: $1"
@@ -75,10 +80,16 @@ if [[ "$agent" == "claude" ]]; then
     fi
 
     if [[ -n "$message" ]]; then
-        exec claude "${args[@]}" "$message"
+        if [[ ${#args[@]} -gt 0 ]]; then
+            exec claude "${args[@]}" "$message"
+        fi
+        exec claude "$message"
     fi
 
-    exec claude "${args[@]}"
+    if [[ ${#args[@]} -gt 0 ]]; then
+        exec claude "${args[@]}"
+    fi
+    exec claude
 fi
 
 combined_prompt=""
@@ -98,7 +109,14 @@ ${message}"
 fi
 
 if [[ -n "$combined_prompt" ]]; then
+    if [[ $resume_latest -eq 1 ]]; then
+        exec codex resume --last "$combined_prompt"
+    fi
     exec codex "$combined_prompt"
+fi
+
+if [[ $resume_latest -eq 1 ]]; then
+    exec codex resume --last
 fi
 
 exec codex

--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -171,7 +171,7 @@ launch() {
     echo ""
 
     tmux new-session -A -s "$session_name" \
-        "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -e OPENAI_API_KEY=\"${OPENAI_API_KEY:-}\" -e ANTHROPIC_API_KEY=\"${ANTHROPIC_API_KEY:-}\" -e DEFAULT_CODE_AGENT=\"$CODE_AGENT\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'exec bash \"$RUNNER_CONTAINER\" --agent \"$CODE_AGENT\"'"
+        "docker exec -it -e CLAUDE_MOBILE=\"${CLAUDE_MOBILE:-}\" -e OPENAI_API_KEY=\"${OPENAI_API_KEY:-}\" -e ANTHROPIC_API_KEY=\"${ANTHROPIC_API_KEY:-}\" -e DEFAULT_CODE_AGENT=\"$CODE_AGENT\" -w '$container_path' ${CONTAINER_NAME} bash -lc 'exec bash \"$RUNNER_CONTAINER\" --agent \"$CODE_AGENT\" --resume-latest'"
 }
 
 launch_manager() {

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -6,11 +6,13 @@ set -euo pipefail
 
 _PASS=0
 _FAIL=0
+_SKIP=0
 _CURRENT_TEST=""
 
 # --- Colors ---
 _RED=$'\033[0;31m'
 _GREEN=$'\033[0;32m'
+_YELLOW=$'\033[1;33m'
 _RESET=$'\033[0m'
 
 # --- Runner ---
@@ -33,15 +35,18 @@ run_tests() {
         export HOME="$TEST_DIR/home"
         export PATH="$TEST_DIR/bin:$_ORIG_PATH"
 
-        local failed=false
+        local result=0
         setup
         if ! "$func"; then
-            failed=true
+            result=$?
         fi
         teardown
         rm -rf "$TEST_DIR"
 
-        if [[ "$failed" == true ]]; then
+        if [[ $result -eq 200 ]]; then
+            echo "  ${_YELLOW}SKIP${_RESET} $func"
+            ((_SKIP++)) || true
+        elif [[ $result -ne 0 ]]; then
             echo "  ${_RED}FAIL${_RESET} $func"
             ((_FAIL++)) || true
         else
@@ -52,10 +57,14 @@ run_tests() {
 }
 
 print_summary() {
-    local total=$((_PASS + _FAIL))
+    local total=$((_PASS + _FAIL + _SKIP))
     echo ""
     if [[ $_FAIL -eq 0 ]]; then
-        echo "${_GREEN}All $total tests passed${_RESET}"
+        if [[ $_SKIP -gt 0 ]]; then
+            echo "${_GREEN}All $((_PASS + _SKIP)) tests passed${_RESET} (${_SKIP} skipped)"
+        else
+            echo "${_GREEN}All $total tests passed${_RESET}"
+        fi
     else
         echo "${_RED}$_FAIL/$total tests failed${_RESET}"
     fi
@@ -64,6 +73,7 @@ print_summary() {
 
 # Save original PATH before any mocks
 _ORIG_PATH="$PATH"
+_ORIG_HOME="$HOME"
 
 # --- Assertions ---
 
@@ -110,6 +120,12 @@ assert_output_contains() {
     local output
     output=$("$@" 2>&1) || true
     assert_contains "$output" "$needle" "output does not contain '$needle'"
+}
+
+skip_test() {
+    local reason="${1:-}"
+    echo "    SKIP${reason:+: $reason}"
+    return 200
 }
 
 # --- Fixtures ---

--- a/tests/test-run-code-agent.sh
+++ b/tests/test-run-code-agent.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Tests for scripts/runtime/run-code-agent.sh
+
+RUNNER_SCRIPT="$REPO_ROOT/scripts/runtime/run-code-agent.sh"
+REAL_TTY_TIMEOUT_SECONDS=4
+
+setup() {
+    mkdir -p "$HOME/.claude" "$HOME/work"
+}
+
+test_claude_resume_latest_starts_fresh_session() {
+    cat > "$TEST_DIR/bin/claude" <<MOCK
+#!/bin/bash
+printf '%s\n' "\$*" > "$HOME/claude.args"
+MOCK
+    chmod +x "$TEST_DIR/bin/claude"
+
+    bash "$RUNNER_SCRIPT" --agent claude --cwd "$HOME/work" --resume-latest
+
+    assert_eq "" "$(cat "$HOME/claude.args")"
+}
+
+test_claude_message_without_resume_passes_prompt() {
+    cat > "$TEST_DIR/bin/claude" <<MOCK
+#!/bin/bash
+printf '%s\n' "\$*" > "$HOME/claude.args"
+MOCK
+    chmod +x "$TEST_DIR/bin/claude"
+
+    bash "$RUNNER_SCRIPT" --agent claude --message "hello"
+
+    assert_eq "hello" "$(cat "$HOME/claude.args")"
+}
+
+test_codex_resume_latest_uses_resume_last() {
+    cat > "$TEST_DIR/bin/codex" <<MOCK
+#!/bin/bash
+printf '%s\n' "\$*" > "$HOME/codex.args"
+MOCK
+    chmod +x "$TEST_DIR/bin/codex"
+
+    bash "$RUNNER_SCRIPT" --agent codex --cwd "$HOME/work" --resume-latest
+
+    assert_eq "resume --last" "$(cat "$HOME/codex.args")"
+}
+
+test_codex_resume_latest_with_message_appends_prompt() {
+    cat > "$TEST_DIR/bin/codex" <<MOCK
+#!/bin/bash
+printf '%s\n' "\$*" > "$HOME/codex.args"
+MOCK
+    chmod +x "$TEST_DIR/bin/codex"
+
+    bash "$RUNNER_SCRIPT" --agent codex --resume-latest --message "hello"
+
+    assert_eq "resume --last hello" "$(cat "$HOME/codex.args")"
+}
+
+test_claude_resume_latest_real_tty_stays_interactive() {
+    [[ "${RUN_REAL_TTY_TESTS:-0}" == "1" ]] || skip_test "set RUN_REAL_TTY_TESTS=1 to enable real TTY checks"
+    command -v claude >/dev/null 2>&1 || skip_test "claude not installed"
+    command -v script >/dev/null 2>&1 || skip_test "script not installed"
+    [[ -n "${_ORIG_HOME:-}" && -d "$_ORIG_HOME/.claude" ]] || skip_test "real Claude home not available"
+
+    local output
+    output=$(
+        ORIG_HOME="$_ORIG_HOME" RUNNER_SCRIPT="$RUNNER_SCRIPT" REPO_ROOT="$REPO_ROOT" REAL_TTY_TIMEOUT_SECONDS="$REAL_TTY_TIMEOUT_SECONDS" \
+        python3 - <<'PY'
+import os
+import shlex
+import signal
+import subprocess
+
+repo = os.environ["REPO_ROOT"]
+runner = os.environ["RUNNER_SCRIPT"]
+home = os.environ["ORIG_HOME"]
+timeout = int(os.environ["REAL_TTY_TIMEOUT_SECONDS"])
+cmd = [
+    "script",
+    "-q",
+    "/dev/null",
+    "bash",
+    "-lc",
+    (
+        f"export HOME={shlex.quote(home)}; "
+        f"cd {shlex.quote(repo)} && "
+        f"bash {shlex.quote(runner)} --agent claude --cwd {shlex.quote(repo)} --resume-latest"
+    ),
+]
+
+proc = subprocess.Popen(
+    cmd,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    start_new_session=True,
+)
+
+try:
+    out, _ = proc.communicate(timeout=timeout)
+    print(f"EXIT {proc.returncode}")
+    print(out[:12000])
+except subprocess.TimeoutExpired:
+    os.killpg(proc.pid, signal.SIGTERM)
+    out, _ = proc.communicate(timeout=2)
+    print("TIMEOUT")
+    print(out[:12000])
+PY
+    )
+
+    assert_contains "$output" "TIMEOUT" "expected Claude TTY launch to stay interactive, got: $output"
+    [[ "$output" != *"sandbox.failIfUnavailable"* ]] || _fail "Claude TTY launch restored broken sandboxed resume path"
+}


### PR DESCRIPTION
## Summary
- keep fresh-launch resume for Codex only and fall back to plain `claude` for new Claude launches
- add runner coverage for `--resume-latest`, including an opt-in real TTY regression test
- wire host and portable menus to pass `--resume-latest` through the shared runner

## Testing
- bash tests/run.sh tests/test-run-code-agent.sh tests/test-start-claude.sh tests/test-start-claude-portable.sh
- RUN_REAL_TTY_TESTS=1 bash tests/run.sh tests/test-run-code-agent.sh