### PR TITLE
Set Cache-Control no-store on nginx /data/

### DIFF
--- a/scripts/runtime/install-macmini-nginx.sh
+++ b/scripts/runtime/install-macmini-nginx.sh
@@ -98,6 +98,11 @@ NGINX
         root $PUBLIC_DIR;
         index index.html;
 
+        location /data/ {
+            add_header Cache-Control "no-store" always;
+            try_files \$uri =404;
+        }
+
         location / {
             try_files \$uri \$uri/ =404;
         }


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-store` header for `/data/` location in `write_server_block()`, applied to both custom-TLS and tailnet-TLS server blocks.
- Belt-and-suspenders alongside cache-busting query strings and `cache: 'no-store'` on the JS side; prevents browsers from caching dashboard data fragments at the server layer.

## Test plan
- [x] Apply on Mac mini host: `~/dev-env/scripts/runtime/install-macmini-nginx.sh` → `nginx -t` clean, LaunchDaemon reloaded
- [x] Verify header present on `/data/`: `curl -skI https://internal.lianghuiyi.com/data/_health.json` → `cache-control: no-store`
- [x] Verify header absent on `/`: same curl on `/` returns no `cache-control: no-store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)