### PR TITLE
Add AbandonProcessGroup to schedule-bridge LaunchAgent

### DIFF
--- a/scripts/runtime/install-macmini-schedule-bridge.sh
+++ b/scripts/runtime/install-macmini-schedule-bridge.sh
@@ -87,6 +87,8 @@ cat > "$PLIST" <<PLIST
   <true/>
   <key>StartInterval</key>
   <integer>60</integer>
+  <key>AbandonProcessGroup</key>
+  <true/>
   <key>WatchPaths</key>
   <array>
     <string>$SCHEDULE_DIR/inbox</string>


### PR DESCRIPTION
## Summary
- Add `<key>AbandonProcessGroup</key><true/>` to the `com.always-on-claude.schedule-bridge` plist so launchd does not reap the detached worker when the main 60s pass exits.

## Why
When the StartInterval-driven `process-schedule-requests.sh` pass exits, launchd by default sends SIGTERM to the entire process group, killing the `nohup ... &` worker wrapper before it can record success. Symptom: `last_exit_code=125` and `"worker disappeared before completion"` even though the in-container script ran to completion. `AbandonProcessGroup` tells launchd to leave child processes alone when the main job exits.

Reference: `man launchd.plist` — *AbandonProcessGroup*.

## Test plan
- [ ] Re-run `scripts/runtime/install-macmini-schedule-bridge.sh` on the Mac mini to regenerate the plist
- [ ] Confirm new plist contains the `AbandonProcessGroup` key (`plutil -p ~/Library/LaunchAgents/com.always-on-claude.schedule-bridge.plist`)
- [ ] Trigger a schedule run that previously hit the 125 / "worker disappeared" failure and verify it now records success
- [ ] Tail `~/.always-on-claude/schedule/logs/launchd.log` across multiple 60s ticks to confirm no regression in normal pass behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)