### PR TITLE
Strengthen worktree cleanup: orphan scan, pre-prune, dirty-merged bucket

### DIFF
--- a/scripts/runtime/worktree-helper.sh
+++ b/scripts/runtime/worktree-helper.sh
@@ -445,17 +445,53 @@ cmd_cleanup() {
     local cleaned=()
     local stale=()
     local active=()
+    local dirty_merged=()
+    local orphans=()
+    local readonly_repos=()
     # shellcheck disable=SC2034  # accessed indirectly via "seen_${bucket}" in record_unique_cleanup_entry
     local seen_cleaned=""
     # shellcheck disable=SC2034
     local seen_stale=""
     # shellcheck disable=SC2034
     local seen_active=""
+    # shellcheck disable=SC2034
+    local seen_dirty_merged=""
+    # shellcheck disable=SC2034
+    local seen_orphans=""
+    # shellcheck disable=SC2034
+    local seen_readonly_repos=""
     local repo_glob_root="$HOME/projects"
 
     if [[ -n "$scope_repo" ]]; then
         repo_glob_root="$scope_repo"
     fi
+
+    # --- Pre-prune pass ---
+    # Walk all repos and run `git worktree prune` to clear registered-but-missing
+    # worktree entries before the main scan. Skip read-only mounts (e.g. virtiofs
+    # ro mount of dev-env inside the container) so we don't churn on errors.
+    local _registered_worktrees="|"
+    while IFS= read -r git_dir; do
+        local _repo_path
+        _repo_path=$(normalize_path "$(dirname "$git_dir")")
+        if [[ -n "$scope_repo" && "$_repo_path" != "$scope_repo" ]]; then
+            continue
+        fi
+        if [[ ! -w "$git_dir" ]]; then
+            record_unique_cleanup_entry readonly_repos "${_repo_path} (read-only mount, prune from host)"
+            continue
+        fi
+        git -C "$_repo_path" worktree prune 2>/dev/null || true
+        # While we're here, build a set of all currently-registered worktree paths
+        # for the orphan-sibling scan below.
+        while IFS= read -r _wt_line; do
+            if [[ "$_wt_line" == "worktree "* ]]; then
+                local _wt
+                _wt=$(normalize_path "${_wt_line#worktree }")
+                _registered_worktrees="${_registered_worktrees}${_wt}|"
+            fi
+        done < <(git -C "$_repo_path" worktree list --porcelain 2>/dev/null)
+    done < <(find "$repo_glob_root" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
 
     # Find all main repos (directories with .git as a directory)
     while IFS= read -r git_dir; do
@@ -502,21 +538,33 @@ cmd_cleanup() {
                     fi
                 done
 
-                if worktree_has_dirty_changes "$wt_path"; then
-                    record_unique_cleanup_entry active "${wt_path} (local edits)"
-                    wt_path=""
-                    wt_branch=""
-                    continue
-                fi
-
                 local default_ref="origin/$default_branch"
                 if ! remote_branch_exists "$repo_path" "$default_branch"; then
                     default_ref="$default_branch"
                 fi
 
+                local _has_unique=true
+                if ! branch_has_unique_commits "$repo_path" "$wt_branch" "$default_ref"; then
+                    _has_unique=false
+                fi
+
+                # Dirty worktrees: surface but never auto-remove. If the branch
+                # has no unique commits beyond default (likely merged), flag it
+                # for review separately so the user knows it can probably go.
+                if worktree_has_dirty_changes "$wt_path"; then
+                    if [[ "$_has_unique" == false ]]; then
+                        record_unique_cleanup_entry dirty_merged "${wt_path} (merged, but has local edits — review)"
+                    else
+                        record_unique_cleanup_entry active "${wt_path} (local edits)"
+                    fi
+                    wt_path=""
+                    wt_branch=""
+                    continue
+                fi
+
                 # Remove worktrees that contribute no unique commits beyond default.
                 # This covers merged branches and untouched branches that simply lag main.
-                if ! branch_has_unique_commits "$repo_path" "$wt_branch" "$default_ref"; then
+                if [[ "$_has_unique" == false ]]; then
                     if [[ "$dry_run" == true ]]; then
                         record_unique_cleanup_entry cleaned "${wt_path} (no unique commits beyond ${default_branch}) [dry-run]"
                     else
@@ -556,6 +604,40 @@ cmd_cleanup() {
         done < <(git -C "$repo_path" worktree list --porcelain 2>/dev/null; echo)
     done < <(find "$repo_glob_root" -maxdepth 3 -name ".git" -type d 2>/dev/null | sort)
 
+    # --- Orphan-sibling scan ---
+    # Walk top-level <basename>--* sibling dirs and remove those that:
+    #   - have a stale `.git` file pointing to a missing gitdir, AND
+    #   - are not registered as a worktree anywhere
+    # We deliberately do NOT auto-remove "empty stub" dirs (no .git at all) —
+    # those can be in-progress user work; we only surface them.
+    while IFS= read -r sibling; do
+        sibling=$(normalize_path "$sibling")
+        if [[ "$_registered_worktrees" == *"|${sibling}|"* ]]; then
+            continue
+        fi
+        if [[ -f "$sibling/.git" ]]; then
+            local _gitdir
+            _gitdir=$(sed -n 's/^gitdir: //p' "$sibling/.git" 2>/dev/null || true)
+            if [[ -n "$_gitdir" && -e "$_gitdir" ]]; then
+                # gitdir is live but worktree isn't registered — odd, leave alone.
+                continue
+            fi
+            if [[ "$dry_run" == true ]]; then
+                record_unique_cleanup_entry orphans "${sibling} (stale gitdir) [dry-run]"
+            else
+                rm -rf "$sibling"
+                if [[ -e "$sibling" ]]; then
+                    record_unique_cleanup_entry active "${sibling} (orphan removal failed)"
+                else
+                    record_unique_cleanup_entry orphans "${sibling} (stale gitdir, removed)"
+                fi
+            fi
+        elif [[ ! -e "$sibling/.git" ]]; then
+            # No .git at all — empty stub. Don't auto-remove; just surface.
+            record_unique_cleanup_entry active "${sibling} (empty stub, not a worktree — review)"
+        fi
+    done < <(find "$repo_glob_root" -maxdepth 1 -mindepth 1 -name '*--*' -type d 2>/dev/null | sort)
+
     # Report results
     if [[ "$quiet" == true ]]; then
         return 0
@@ -590,6 +672,30 @@ cmd_cleanup() {
     fi
 
     echo ""
+    if [[ ${#dirty_merged[@]} -gt 0 ]]; then
+        echo "  Dirty but merged (review):"
+        for entry in "${dirty_merged[@]}"; do
+            echo "    $entry"
+        done
+        echo ""
+    fi
+
+    if [[ ${#orphans[@]} -gt 0 ]]; then
+        echo "  Orphans (stale gitdir, removed):"
+        for entry in "${orphans[@]}"; do
+            echo "    $entry"
+        done
+        echo ""
+    fi
+
+    if [[ ${#readonly_repos[@]} -gt 0 ]]; then
+        echo "  Read-only repos (skipped):"
+        for entry in "${readonly_repos[@]}"; do
+            echo "    $entry"
+        done
+        echo ""
+    fi
+
     if [[ ${#active[@]} -gt 0 ]]; then
         echo "  Active:"
         for entry in "${active[@]}"; do

--- a/tests/test-worktree-helper.sh
+++ b/tests/test-worktree-helper.sh
@@ -3,8 +3,11 @@
 
 HELPER="$REPO_ROOT/scripts/runtime/worktree-helper.sh"
 
-# Override HOME/projects to TEST_DIR for find discovery
+# Override HOME/projects to TEST_DIR for find discovery.
+# Unset DEV_ENV/PROJECTS_DIR so the helper doesn't load /home/dev/dev-env/.env
+# and override paths to the real workspace (would leak host state into tests).
 setup() {
+    unset DEV_ENV PROJECTS_DIR
     mkdir -p "$HOME/projects"
 }
 
@@ -366,6 +369,79 @@ MOCK
 
     bash "$HELPER" cleanup >/dev/null
     assert_file_not_exists "$worktree"
+}
+
+test_cleanup_removes_orphan_sibling_with_stale_gitdir() {
+    local repo
+    repo=$(create_test_repo projects/myrepo)
+    create_test_worktree "$repo" "orphan-branch"
+
+    # Simulate the "gitdir gone but worktree dir remains" failure mode:
+    # delete the .git/worktrees/<name> entry so the .git file in the worktree
+    # points at a path that no longer exists.
+    rm -rf "$repo/.git/worktrees/myrepo--orphan-branch"
+
+    local bare="$TEST_DIR/bare-remote"
+    git init -q --bare "$bare"
+    git -C "$repo" remote add origin "$bare" 2>/dev/null || true
+    local default_branch
+    default_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
+    git -C "$repo" push -q origin "${default_branch}" 2>/dev/null || true
+
+    bash "$HELPER" cleanup >/dev/null
+    assert_file_not_exists "$HOME/projects/myrepo--orphan-branch"
+}
+
+test_cleanup_dirty_but_merged_worktree_is_flagged_not_removed() {
+    local repo
+    repo=$(create_test_repo projects/myrepo)
+    create_test_worktree "$repo" "idle-dirty"
+
+    # Advance main so the branch has no unique commits beyond it.
+    touch "$repo/mainfile"
+    git -C "$repo" add mainfile
+    git -C "$repo" commit -q -m "main moves"
+
+    # Worktree has uncommitted local edits.
+    echo "scratch" > "$HOME/projects/myrepo--idle-dirty/scratch.txt"
+
+    local bare="$TEST_DIR/bare-remote"
+    git init -q --bare "$bare"
+    git -C "$repo" remote add origin "$bare" 2>/dev/null || true
+    local default_branch
+    default_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
+    git -C "$repo" push -q origin "${default_branch}" 2>/dev/null || true
+
+    local output
+    output=$(bash "$HELPER" cleanup)
+    assert_contains "$output" "Dirty but merged"
+    assert_contains "$output" "myrepo--idle-dirty (merged, but has local edits"
+    assert_file_exists "$HOME/projects/myrepo--idle-dirty/.git"
+}
+
+test_cleanup_pre_prune_runs_before_main_loop() {
+    # Verify the pre-prune pass clears a stale .git/worktrees/<name> entry
+    # before the orphan-sibling scan tries to inspect the on-disk dir.
+    local repo
+    repo=$(create_test_repo projects/myrepo)
+    create_test_worktree "$repo" "ghost"
+
+    # Move the worktree dir out of the way so it looks "missing" to git, but
+    # keep the .git/worktrees/<name> entry so it shows up in `worktree list`
+    # as prunable. After pre-prune, the entry should be gone.
+    mv "$HOME/projects/myrepo--ghost" "$HOME/projects/myrepo--ghost.away"
+
+    local bare="$TEST_DIR/bare-remote"
+    git init -q --bare "$bare"
+    git -C "$repo" remote add origin "$bare" 2>/dev/null || true
+    local default_branch
+    default_branch=$(git -C "$repo" rev-parse --abbrev-ref HEAD)
+    git -C "$repo" push -q origin "${default_branch}" 2>/dev/null || true
+
+    bash "$HELPER" cleanup >/dev/null
+
+    # Pre-prune should have removed the registration.
+    [[ ! -d "$repo/.git/worktrees/myrepo--ghost" ]] || _fail "pre-prune did not clear .git/worktrees/myrepo--ghost"
 }
 
 test_sync_repo_resets_to_default_branch_and_cleans_files() {


### PR DESCRIPTION
## Summary

The login-time worktree cleanup (`worktree-helper.sh cleanup`, run by `start-claude.sh` on every menu open) was missing three failure modes that let cruft accumulate under `~/projects`. We just hand-cleaned 33 stale dirs across `ainbox`, `dashboard`, and `agent-team-playground` — most of which the cleanup pass should have caught on its own.

### Failure modes addressed

1. **Orphan sibling dirs invisible to the scan.** When `.git/worktrees/<name>/` is deleted out from under a worktree (manual cleanup, host/container divergence, etc.), the on-disk dir keeps a stale `.git` pointer file. `find -type d -name .git` skips it (it's a file), and `git worktree list` has already pruned it — so the loop never sees it. Now scanned explicitly.

2. **No pre-prune pass.** `git worktree prune` was only called *after* a successful `worktree remove`, so registered-but-missing entries (and "prunable" entries from another machine) lingered. Now run once per repo at the top of `cmd_cleanup`.

3. **Dirty-but-merged worktrees vanished into "Active" forever.** A worktree whose branch has no unique commits beyond default but still has local edits (e.g. an auto-regenerated `terraform.lock.hcl`) was treated as active and never surfaced. New `Dirty but merged (review):` bucket flags these without auto-removing — the user decides.

### Bonus

- Read-only repo mounts (e.g. virtiofs ro mount of `dev-env` inside the container) are detected and reported under `Read-only repos (skipped):` instead of producing prune errors.
- Test setup now unsets `DEV_ENV`/`PROJECTS_DIR` so the helper's `.env` load doesn't leak host paths into fixtures (this was already silently breaking the `list_repos` assertions, masked by an unrelated test-runner bug).

## Test plan

- [x] `bash tests/run.sh tests/test-worktree-helper.sh` — all 24 tests pass (21 existing + 3 new)
- [x] New orphan test verified to fail against the unmodified helper (regression catch)
- [x] Smoke-tested end-to-end against a synthetic mess containing all three failure modes — orphan removed, dirty-merged flagged, registered worktrees correctly handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)