### PR TITLE
Fix file_age_seconds returning false on Linux

### DIFF
--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -237,7 +237,20 @@ file_age_seconds() {
     local path="$1"
     [[ -e "$path" ]] || return 1
     local modified
-    modified=$(stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null || return 1)
+    # Try GNU stat (Linux) first, then BSD/macOS. Old order trusted whatever
+    # the first call wrote to stdout, but on GNU systems `stat -f %m FILE`
+    # exits 0 with a multi-line filesystem dump — that gets bound to `modified`
+    # and the arithmetic below explodes under `set -u` with "File: unbound
+    # variable", aborting the surrounding `$()` subshell before any `||`
+    # fallback in the caller can fire. Net effect: cleanup_due always
+    # returned false on Linux, so picker-driven cleanup never ran.
+    if modified=$(stat -c %Y "$path" 2>/dev/null); then
+        :
+    elif modified=$(stat -f %m "$path" 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
     echo $(( $(now_epoch) - modified ))
 }
 

--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -288,7 +288,20 @@ file_age_seconds() {
     local path="$1"
     [[ -e "$path" ]] || return 1
     local modified
-    modified=$(stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null || return 1)
+    # Try GNU stat (Linux) first, then BSD/macOS. Old order trusted whatever
+    # the first call wrote to stdout, but on GNU systems `stat -f %m FILE`
+    # exits 0 with a multi-line filesystem dump — that gets bound to `modified`
+    # and the arithmetic below explodes under `set -u` with "File: unbound
+    # variable", aborting the surrounding `$()` subshell before any `||`
+    # fallback in the caller can fire. Net effect: cleanup_due always
+    # returned false on Linux, so picker-driven cleanup never ran.
+    if modified=$(stat -c %Y "$path" 2>/dev/null); then
+        :
+    elif modified=$(stat -f %m "$path" 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
     echo $(( $(now_epoch) - modified ))
 }
 

--- a/tests/test-start-claude-portable.sh
+++ b/tests/test-start-claude-portable.sh
@@ -217,3 +217,65 @@ test_prepare_project_launch_blocks_when_base_repo_has_live_session() {
     assert_eq "1" "$exit_code"
     assert_contains "$output" "live tmux session"
 }
+
+# --- file_age_seconds / cleanup_due ---
+
+test_file_age_seconds_returns_positive_integer_for_recent_file() {
+    local f="$TEST_DIR/recent"
+    touch "$f"
+
+    local age
+    age=$(file_age_seconds "$f")
+    [[ "$age" =~ ^[0-9]+$ ]] || _fail "expected integer, got '$age'"
+    [[ "$age" -lt 60 ]] || _fail "expected age <60s for just-touched file, got $age"
+}
+
+test_file_age_seconds_handles_old_file() {
+    local f="$TEST_DIR/old"
+    touch -d '2026-01-01 00:00:00' "$f"
+
+    local age
+    age=$(file_age_seconds "$f")
+    [[ "$age" =~ ^[0-9]+$ ]] || _fail "expected integer, got '$age'"
+    [[ "$age" -gt 86400 ]] || _fail "expected age >1 day for Jan 1 file, got $age"
+}
+
+test_file_age_seconds_returns_nonzero_for_missing_file() {
+    local exit_code=0
+    file_age_seconds "$TEST_DIR/does-not-exist" >/dev/null 2>&1 || exit_code=$?
+    [[ "$exit_code" -ne 0 ]] || _fail "expected non-zero exit for missing file"
+}
+
+test_cleanup_due_true_when_stamp_is_old() {
+    # Regression: file_age_seconds used `stat -f %m` first, which on GNU
+    # systems exits 0 with a multi-line filesystem dump instead of an
+    # mtime. The arithmetic on that string aborted the surrounding
+    # subshell under `set -u`, the `|| echo TTL+1` fallback never ran,
+    # and cleanup_due always returned false on Linux — so picker-driven
+    # cleanup never fired.
+    MENU_CACHE_DIR="$TEST_DIR/cache"
+    MENU_CLEANUP_TTL=300
+    mkdir -p "$MENU_CACHE_DIR"
+    touch -d '2026-01-01 00:00:00' "$MENU_CACHE_DIR/cleanup.stamp"
+
+    cleanup_due || _fail "cleanup_due should be true when stamp is months old"
+}
+
+test_cleanup_due_false_when_stamp_is_fresh() {
+    MENU_CACHE_DIR="$TEST_DIR/cache"
+    MENU_CLEANUP_TTL=300
+    mkdir -p "$MENU_CACHE_DIR"
+    touch "$MENU_CACHE_DIR/cleanup.stamp"
+
+    if cleanup_due; then
+        _fail "cleanup_due should be false for just-touched stamp"
+    fi
+}
+
+test_cleanup_due_true_when_stamp_missing() {
+    MENU_CACHE_DIR="$TEST_DIR/cache-empty"
+    MENU_CLEANUP_TTL=300
+    mkdir -p "$MENU_CACHE_DIR"
+
+    cleanup_due || _fail "cleanup_due should be true when stamp is missing"
+}

--- a/tests/test-start-claude.sh
+++ b/tests/test-start-claude.sh
@@ -566,3 +566,65 @@ test_prepare_project_launch_blocks_when_base_repo_has_live_session() {
     assert_eq "1" "$exit_code"
     assert_contains "$output" "live tmux session"
 }
+
+# --- file_age_seconds / cleanup_due ---
+
+test_file_age_seconds_returns_positive_integer_for_recent_file() {
+    local f="$TEST_DIR/recent"
+    touch "$f"
+
+    local age
+    age=$(file_age_seconds "$f")
+    [[ "$age" =~ ^[0-9]+$ ]] || _fail "expected integer, got '$age'"
+    [[ "$age" -lt 60 ]] || _fail "expected age <60s for just-touched file, got $age"
+}
+
+test_file_age_seconds_handles_old_file() {
+    local f="$TEST_DIR/old"
+    touch -d '2026-01-01 00:00:00' "$f"
+
+    local age
+    age=$(file_age_seconds "$f")
+    [[ "$age" =~ ^[0-9]+$ ]] || _fail "expected integer, got '$age'"
+    [[ "$age" -gt 86400 ]] || _fail "expected age >1 day for Jan 1 file, got $age"
+}
+
+test_file_age_seconds_returns_nonzero_for_missing_file() {
+    local exit_code=0
+    file_age_seconds "$TEST_DIR/does-not-exist" >/dev/null 2>&1 || exit_code=$?
+    [[ "$exit_code" -ne 0 ]] || _fail "expected non-zero exit for missing file"
+}
+
+test_cleanup_due_true_when_stamp_is_old() {
+    # Regression: file_age_seconds used `stat -f %m` first, which on GNU
+    # systems exits 0 with a multi-line filesystem dump instead of an
+    # mtime. The arithmetic on that string aborted the surrounding
+    # subshell under `set -u`, the `|| echo TTL+1` fallback never ran,
+    # and cleanup_due always returned false on Linux — so picker-driven
+    # cleanup never fired.
+    MENU_CACHE_DIR="$TEST_DIR/cache"
+    MENU_CLEANUP_TTL=300
+    mkdir -p "$MENU_CACHE_DIR"
+    touch -d '2026-01-01 00:00:00' "$MENU_CACHE_DIR/cleanup.stamp"
+
+    cleanup_due || _fail "cleanup_due should be true when stamp is months old"
+}
+
+test_cleanup_due_false_when_stamp_is_fresh() {
+    MENU_CACHE_DIR="$TEST_DIR/cache"
+    MENU_CLEANUP_TTL=300
+    mkdir -p "$MENU_CACHE_DIR"
+    touch "$MENU_CACHE_DIR/cleanup.stamp"
+
+    if cleanup_due; then
+        _fail "cleanup_due should be false for just-touched stamp"
+    fi
+}
+
+test_cleanup_due_true_when_stamp_missing() {
+    MENU_CACHE_DIR="$TEST_DIR/cache-empty"
+    MENU_CLEANUP_TTL=300
+    mkdir -p "$MENU_CACHE_DIR"
+
+    cleanup_due || _fail "cleanup_due should be true when stamp is missing"
+}


### PR DESCRIPTION
## Summary

Picker-driven cleanup has been silently broken on every Linux install since `file_age_seconds` was written. `cleanup_due` always returned false on Linux, so `run_background_maintenance` skipped the cleanup branch every time the picker rendered, the cleanup stamp was never refreshed, and merged worktrees accumulated indefinitely.

## Root cause

`file_age_seconds` tried `stat -f %m` first (BSD form for mtime) and fell back to `stat -c %Y` (GNU):

```bash
modified=$(stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null || return 1)
echo $(( $(now_epoch) - modified ))
```

On GNU stat, `-f` means "filesystem mode" and `%m` is interpreted as a path, so the call exits 0 with a multi-line filesystem-info dump on stdout (and a warning on stderr that `2>/dev/null` swallows). That string gets bound to `modified`. The arithmetic then tries to parse `"  File: ..."` as a variable, hits unbound variable under `set -u`, and the whole `$()` subshell aborts — before the caller's `|| echo TTL+1` fallback can run. `age` ends up empty, `[[ "" -ge "300" ]]` is false, `cleanup_due` returns false.

I hit this on the live workspace: picker entered many times across two days, `~/.cache/aoc/start-menu/cleanup.stamp` still pinned to its initial mtime, merged worktrees never auto-cleaned. PR #137 fixed a separate bug in `worktree-helper` but couldn't have helped here, since the helper was never being called.

## Fix

Reorder the stat fallback to GNU first, and check exit codes properly instead of trusting whatever stdout came out:

```bash
if modified=$(stat -c %Y "$path" 2>/dev/null); then :
elif modified=$(stat -f %m "$path" 2>/dev/null); then :
else return 1
fi
```

`modified` is now always a clean integer. macOS still works (GNU stat absent → `-c %Y` exits non-zero → BSD fallback runs).

The same broken function is duplicated in both `start-claude.sh` and `start-claude-portable.sh` — patched both.

## Test plan

- [x] Added 6 regression tests in `test-start-claude.sh` and `test-start-claude-portable.sh` (3 for `file_age_seconds`, 3 for `cleanup_due`)
- [x] Confirmed tests print 6 visible `ASSERT FAILED` lines without the fix; clean run with the fix
- [x] `bash tests/run.sh tests/test-start-claude.sh tests/test-start-claude-portable.sh tests/test-worktree-helper.sh` — all pass
- [x] Verified live: with the fix, `cleanup_due` returns true for the months-old stamp file

🤖 Generated with [Claude Code](https://claude.com/claude-code)