### PR TITLE
Detect squash-merges in worktree cleanup; capacity-gate launches

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,12 @@ services:
       # Mount as a single file (overrides the ro mount for just this file)
       - ~/.ssh/known_hosts:/home/dev/.ssh/known_hosts
 
+      # Published dashboard web root served by host nginx.
+      - ~/aoc-data/public:/srv/public
+
+      # Gmail/Calendar OAuth state used by dashboard REST fetchers.
+      - ~/aoc-data/codex/gmail-mcp:/home/dev/.codex/gmail-mcp
+
     environment:
       - NODE_ENV=development
 

--- a/scripts/lib/start-menu-common.sh
+++ b/scripts/lib/start-menu-common.sh
@@ -168,6 +168,10 @@ check_session_limit() {
         return 0
     fi
 
+    check_new_session_capacity
+}
+
+check_new_session_capacity() {
     local current max
     current=$(count_sessions)
     max=$(get_max_sessions)
@@ -576,7 +580,10 @@ run_picker_loop() {
         compute_default
         show_menu
 
-        read -r -p "  > " choice || true
+        if ! read -r -p "  > " choice; then
+            echo ""
+            return 0
+        fi
 
         if [[ "$choice" == "m" ]]; then
             prepare_manager_launch || continue

--- a/scripts/portable/start-claude-portable.sh
+++ b/scripts/portable/start-claude-portable.sh
@@ -366,6 +366,10 @@ prepare_project_launch() {
         return 1
     fi
 
+    if ! check_new_session_capacity; then
+        return 1
+    fi
+
     if ! sync_repo_or_warn "$main_path"; then
         worktree_info=$(bash "$WORKTREE_HELPER" recover-dirty-repo "$main_path" 2>/dev/null) || {
             echo ""

--- a/scripts/runtime/aoc-menu-mac.sh
+++ b/scripts/runtime/aoc-menu-mac.sh
@@ -18,4 +18,9 @@ if ! "$DOCKER" ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
 fi
 
 exec "$DOCKER" exec -it "$CONTAINER" bash -lc \
-  'exec bash "$HOME/dev-env/scripts/portable/start-claude-portable.sh"'
+  'for root in "$HOME/dev-env" "$HOME/projects/dev-env" "$HOME/projects/always-on-claude"; do
+     script="$root/scripts/portable/start-claude-portable.sh"
+     if [ -x "$script" ]; then export DEV_ENV="$root"; exec bash "$script"; fi
+   done
+   echo "Could not find start-claude-portable.sh in expected locations" >&2
+   exit 1'

--- a/scripts/runtime/start-claude.sh
+++ b/scripts/runtime/start-claude.sh
@@ -408,8 +408,6 @@ prepare_project_launch() {
     local main_path="$1" repo_name="$2"
     local worktree_info
 
-    wait_for_container
-
     if session_matches_repo_path "$main_path"; then
         echo ""
         echo "  Cannot start a new session from $repo_name."
@@ -418,6 +416,12 @@ prepare_project_launch() {
         echo ""
         return 1
     fi
+
+    if ! check_new_session_capacity; then
+        return 1
+    fi
+
+    wait_for_container
 
     if ! sync_repo_or_warn "$main_path"; then
         worktree_info=$(bash "$WORKTREE_HELPER" recover-dirty-repo "$main_path" 2>/dev/null) || {

--- a/scripts/runtime/worktree-helper.sh
+++ b/scripts/runtime/worktree-helper.sh
@@ -379,9 +379,13 @@ days_since_last_commit() {
 
 branch_has_unique_commits() {
     local repo_path="$1" branch="$2" default_ref="$3"
-    local ahead_count
-    ahead_count=$(git -C "$repo_path" rev-list --count "${default_ref}..${branch}" 2>/dev/null || echo "0")
-    [[ "$ahead_count" -gt 0 ]]
+    # `git cherry` prefixes "+ <sha>" for unique patches and "- <sha>" for
+    # patches whose patch-id already exists upstream. This catches squash- and
+    # rebase-merges, where rev-list would still see the original commits as
+    # ahead. Empty output also means nothing unique.
+    local unique
+    unique=$(git -C "$repo_path" cherry "$default_ref" "$branch" 2>/dev/null | grep -c '^+' || true)
+    [[ "${unique:-0}" -gt 0 ]]
 }
 
 # Human-readable time since last commit

--- a/tests/test-worktree-helper.sh
+++ b/tests/test-worktree-helper.sh
@@ -508,3 +508,38 @@ test_sync_repo_resets_to_default_branch_and_cleans_files() {
     assert_eq "$initial_branch" "$(git -C "$repo" branch --show-current)"
     assert_file_not_exists "$repo/extra"
 }
+
+test_cleanup_removes_squash_merged_branch() {
+    # Squash-merge equivalent: feature commit's patch lands on main under a
+    # different SHA. rev-list --count would still see the branch as ahead
+    # (it compares SHAs); git cherry compares patch-ids and reports nothing
+    # unique. Main must be advanced independently so cherry-pick creates a
+    # divergent commit instead of fast-forwarding.
+    local repo
+    repo=$(create_test_repo projects/myrepo)
+    local default_branch
+    default_branch=$(git -C "$repo" branch --show-current)
+
+    git -C "$repo" checkout -q -b feat/squashed
+    echo "feature work" > "$repo/feature.txt"
+    git -C "$repo" add feature.txt
+    git -C "$repo" commit -q -m "Feature work"
+    local feat_sha
+    feat_sha=$(git -C "$repo" rev-parse HEAD)
+
+    git -C "$repo" checkout -q "$default_branch"
+    echo "unrelated" > "$repo/mainfile.txt"
+    git -C "$repo" add mainfile.txt
+    git -C "$repo" commit -q -m "Unrelated main change"
+    git -C "$repo" cherry-pick "$feat_sha" >/dev/null
+
+    local bare="$TEST_DIR/bare-remote"
+    git init -q --bare "$bare"
+    git -C "$repo" remote add origin "$bare" 2>/dev/null || true
+    git -C "$repo" push -q origin "$default_branch" 2>/dev/null || true
+
+    bash "$HELPER" create "$repo" feat/squashed >/dev/null
+
+    bash "$HELPER" cleanup >/dev/null
+    assert_file_not_exists "${repo}--feat-squashed"
+}


### PR DESCRIPTION
## Summary
- `worktree-helper`: `branch_has_unique_commits` switches from `rev-list --count` (SHA compare) to `git cherry` (patch-id compare). Squash- and rebase-merged branches were stuck on disk forever — their original commits never appear on main verbatim. This is the default GitHub PR merge path, so the previous logic missed most mergeable worktrees.
- `start-menu-common` / `start-claude` / `start-claude-portable`: capacity-gate `prepare_project_launch` so over-cap users get the message immediately, before sync or container wait.
- `aoc-menu-mac`: probe known dev-env locations and export `DEV_ENV`.
- `docker-compose`: mount `~/aoc-data/public` and `codex/gmail-mcp` into the container.

## Test plan
- [x] `bash tests/run.sh tests/test-worktree-helper.sh tests/test-start-claude.sh tests/test-start-claude-portable.sh` — all green (26 + 32 + 15)
- [x] New `test_cleanup_removes_squash_merged_branch` fails on pre-fix `worktree-helper` (verified by reverting and rerunning)
- [ ] Manually exercise picker capacity gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)